### PR TITLE
Add API for available langs and autocompletion to lang selector

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -7,11 +7,11 @@ const $ = require('jquery');
 $(function () {
     // Initiate Select2, which allows dynamic entry of languages.
     $('#lang').select2({
-        tags: true,
         theme: 'bootstrap',
     });
 
     // Show engine-specific options.
+    // TODO: Update the Select2 options with available languages.
     $('#engine').on('change',  e => {
         $('.engine-options').addClass('hidden');
         $(`#${e.target.value}-options`).removeClass('hidden');

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -50,7 +50,7 @@ class ExceptionListener
             return;
         }
 
-        $isApi = str_contains($this->request->getPathInfo(), 'api.php');
+        $isApi = str_contains($this->request->getPathInfo(), '/api');
         $params = array_merge(
             OcrController::$params,
             $this->request->query->all()

--- a/templates/output.html.twig
+++ b/templates/output.html.twig
@@ -10,8 +10,14 @@
         <div class="form-group">
             <label for="lang">{{ msg('language-code') }}</label>
             <select id="lang" class="form-control" name="langs[]" multiple>
-                {% for lang in langs %}
-                    <option value="{{ lang }}" selected>{{ lang }}</option>
+                {% for lang in available_langs %}
+                    <option value="{{ lang }}" {% if lang in langs %}selected{% endif %}>
+                        {{ lang }}
+                        {% if lang_name(lang) is not empty %}
+                            &ndash;
+                            {{ lang_name(lang) }}
+                        {% endif %}
+                    </option>
                 {% endfor %}
             </select>
             <p class="help-block">{{ msg( 'language-code-help' ) }}</p>


### PR DESCRIPTION
New API endpoint is at /api/available_langs. For consistency /api can
now be accepted instead of /api.php

Also renamed controller methods to have 'Action' in the name to
distinguish which ones have routes.

Refactored constructing the API JsonResponse object.

Bug: https://phabricator.wikimedia.org/T282073