### PR TITLE
Add language map and refactor EngineBase::getValidLangs()

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -3,19 +3,55 @@ import './styles/app.css';
 import 'select2';
 
 const $ = require('jquery');
+const $select2 = $('#lang');
+
+/**
+ * Populate and re-initialize the Select2 input with languages supported by the given engine.
+ * @param {String} engine Supported engine ID such as 'google' or 'tesseract'.
+ */
+function updateSelect2Options(engine)
+{
+    $.getJSON(`/api/available_langs?engine=${engine}`).then(response => {
+        const langs = response.available_langs;
+        let data = [];
+
+        // Transform to data structure needed by Select2.
+        Object.keys(langs).forEach(lang => {
+            data.push({
+                id: lang,
+                text: `${lang} – ${langs[lang]}`,
+            });
+        });
+
+        // First clear any existing selections and empty all options.
+        $select2.val(null)
+            .empty()
+            .trigger('change');
+
+        // Update Select2 with the new options.
+        data.forEach(datum => {
+            const option = new Option(datum.text, datum.id, false, false);
+            $select2.append(option);
+        });
+        $select2.trigger({
+            type: 'select2:select',
+            params: { data }
+        });
+    });
+}
 
 $(function () {
     // Initiate Select2, which allows dynamic entry of languages.
-    $('#lang').select2({
+    $select2.select2({
         theme: 'bootstrap',
     });
 
     // Show engine-specific options.
-    // TODO: Update the Select2 options with available languages.
     $('#engine').on('change',  e => {
+        updateSelect2Options(e.target.value);
         $('.engine-options').addClass('hidden');
         $(`#${e.target.value}-options`).removeClass('hidden');
-    }).trigger('change');
+    });
 
     // For the result page. Makes the 'Copy' button copy the transcription to the clipboard.
     const $copyButton = $('#copy-button');

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -29,6 +29,8 @@ services:
 
     # https://symfony.com/doc/current/service_container/parent_services.html
     App\Engine\EngineBase:
+        arguments:
+            $projectDir: '%kernel.project_dir%'
         calls:
             - setImageHosts: [ '%env(APP_IMAGE_HOSTS)%' ]
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,6 +13,7 @@
         <server name="SHELL_VERBOSITY" value="-1" />
         <server name="SYMFONY_PHPUNIT_REMOVE" value="" />
         <server name="SYMFONY_PHPUNIT_VERSION" value="8.5" />
+        <server name="KERNEL_CLASS" value="App\Kernel" />
 
         <!-- ###+ symfony/mailer ### -->
         <!-- MAILER_DSN=smtp://localhost -->

--- a/public/langs.json
+++ b/public/langs.json
@@ -1,0 +1,486 @@
+{
+    "af": {
+        "tesseract": "afr",
+        "google": "af"
+    },
+    "am": {
+        "tesseract": "amh",
+        "google": "am"
+    },
+    "ar": {
+        "tesseract": "ara",
+        "google": "ar"
+    },
+    "as": {
+        "tesseract": "asm",
+        "google": "as"
+    },
+    "az": {
+        "tesseract": "aze",
+        "google": "az"
+    },
+    "az-cyrl": {
+        "tesseract": "aze_cyrl",
+        "google": "az-Cyrl"
+    },
+    "be": {
+        "tesseract": "bel",
+        "google": "be"
+    },
+    "bg": {
+        "tesseract": "bul",
+        "google": "bg"
+    },
+    "bn": {
+        "tesseract": "ben",
+        "google": "bn"
+    },
+    "bo": {
+        "tesseract": "bod",
+        "google": "bo"
+    },
+    "br": {
+        "tesseract": "bre",
+        "google": "br"
+    },
+    "bs": {
+        "tesseract": "bos",
+        "google": "bs"
+    },
+    "ca": {
+        "tesseract": "cat",
+        "google": "ca"
+    },
+    "ceb": {
+        "tesseract": "ceb",
+        "google": "ceb"
+    },
+    "chr": {
+        "tesseract": "chr",
+        "google": "chr"
+    },
+    "co": {
+        "tesseract": "cos"
+    },
+    "cs": {
+        "tesseract": "ces",
+        "google": "cs"
+    },
+    "cy": {
+        "tesseract": "cym",
+        "google": "cy"
+    },
+    "da": {
+        "tesseract": "dan",
+        "google": "da"
+    },
+    "de": {
+        "tesseract": "deu",
+        "google": "de"
+    },
+    "de-frk": {
+        "tesseract": "frk"
+    },
+    "dv": {
+        "google": "dv"
+    },
+    "dz": {
+        "tesseract": "dzo",
+        "google": "dz"
+    },
+    "el": {
+        "tesseract": "ell",
+        "google": "el"
+    },
+    "en": {
+        "tesseract": "eng",
+        "google": "en"
+    },
+    "enm": {
+        "tesseract": "enm",
+        "google": "enm"
+    },
+    "eo": {
+        "tesseract": "epo",
+        "google": "eo"
+    },
+    "equ": {
+        "tesseract": "equ"
+    },
+    "es": {
+        "tesseract": "spa",
+        "google": "es"
+    },
+    "es-old": {
+        "tesseract": "spa_old"
+    },
+    "et": {
+        "tesseract": "est",
+        "google": "et"
+    },
+    "eu": {
+        "tesseract": "eus",
+        "google": "eu"
+    },
+    "fa": {
+        "tesseract": "fas",
+        "google": "fa"
+    },
+    "fi": {
+        "tesseract": "fin",
+        "google": "fi"
+    },
+    "fo": {
+        "tesseract": "fao",
+        "google": "fo"
+    },
+    "fr": {
+        "tesseract": "fra",
+        "google": "fr"
+    },
+    "fro": {
+        "tesseract": "frm",
+        "google": "fro"
+    },
+    "fy": {
+        "tesseract": "fry",
+        "google": "fy"
+    },
+    "ga": {
+        "tesseract": "gle",
+        "google": "ga"
+    },
+    "gd": {
+        "tesseract": "gla",
+        "google": "gd"
+    },
+    "gl": {
+        "tesseract": "glg",
+        "google": "gl"
+    },
+    "grc": {
+        "tesseract": "grc",
+        "google": "grc"
+    },
+    "gu": {
+        "tesseract": "guj",
+        "google": "gu"
+    },
+    "gv": {
+        "tesseract": ""
+    },
+    "he": {
+        "tesseract": "heb",
+        "google": "iw"
+    },
+    "hi": {
+        "tesseract": "hin",
+        "google": "hi"
+    },
+    "hr": {
+        "tesseract": "hrv",
+        "google": "hr"
+    },
+    "ht": {
+        "tesseract": "hat",
+        "google": "ht"
+    },
+    "hu": {
+        "tesseract": "hun",
+        "google": "hu"
+    },
+    "hy": {
+        "tesseract": "hye",
+        "google": "hy"
+    },
+    "id": {
+        "tesseract": "ind",
+        "google": "id"
+    },
+    "is": {
+        "tesseract": "isl",
+        "google": "is"
+    },
+    "it": {
+        "tesseract": "ita",
+        "google": "it"
+    },
+    "it-old": {
+        "tesseract": "ita_old"
+    },
+    "iu": {
+        "tesseract": "iku"
+    },
+    "ja": {
+        "tesseract": "jpn",
+        "google": "ja"
+    },
+    "jv": {
+        "tesseract": "jav",
+        "google": "jv"
+    },
+    "ka": {
+        "tesseract": "kat",
+        "google": "ka"
+    },
+    "ka-old": {
+        "tesseract": "kat_old"
+    },
+    "kk": {
+       "tesseract": "kaz",
+        "google": "kk"
+    },
+    "km": {
+        "tesseract": "khm",
+        "google": "km"
+    },
+    "ky": {
+        "tesseract": "kir",
+        "google": "ky"
+    },
+    "kn": {
+        "tesseract": "kan",
+        "google": "kn"
+    },
+    "ko": {
+        "tesseract": "kor",
+        "google": "ko"
+    },
+    "ko-vert": {
+        "tesseract": "kor_vert"
+    },
+    "ku": {
+        "tesseract": "kmr"
+    },
+    "la": {
+        "tesseract": "lat",
+        "google": "la"
+    },
+    "lb": {
+        "tesseract": "ltz"
+    },
+    "lo": {
+        "tesseract": "lao",
+        "google": "lo"
+    },
+    "lt": {
+        "tesseract": "lit",
+        "google": "lt"
+    },
+    "lv": {
+        "tesseract": "lav",
+        "google": "lv"
+    },
+    "mi": {
+        "tesseract": "mri",
+        "google": "mi"
+    },
+    "mk": {
+        "tesseract": "mkd",
+        "google": "mk"
+    },
+    "ml": {
+        "tesseract": "mal",
+        "google": "ml"
+    },
+    "mn": {
+        "tesseract": "mon",
+        "google": "mn"
+    },
+    "mr": {
+        "tesseract": "mar",
+        "google": "mr"
+    },
+    "ms": {
+        "tesseract": "msa",
+        "google": "ms"
+    },
+    "mt": {
+        "tesseract": "mlt",
+        "google": "mt"
+    },
+    "my": {
+        "tesseract": "mya",
+        "google": "my"
+    },
+    "ne": {
+        "tesseract": "nep",
+        "google": "ne"
+    },
+    "nl": {
+        "tesseract": "nld",
+        "google": "nl"
+    },
+    "no": {
+        "tesseract": "nor",
+        "google": "no"
+    },
+    "oc": {
+        "tesseract": "oci",
+        "google": "oc"
+    },
+    "or": {
+        "tesseract": "ori",
+        "google": "or"
+    },
+    "osd": {
+        "tesseract": "osd"
+    },
+    "pa": {
+        "tesseract": "pan",
+        "google": ""
+    },
+    "pl": {
+        "tesseract": "pol",
+        "google": "pl"
+    },
+    "ps": {
+        "tesseract": "pus",
+        "google": "ps"
+    },
+    "pt": {
+        "tesseract": "por",
+        "google": "pt"
+    },
+    "ur": {
+        "tesseract": "urd",
+        "google": "ur"
+    },
+    "qu": {
+        "tesseract": "que",
+        "google": "qu"
+    },
+    "ro": {
+        "tesseract": "ron",
+        "google": "ro"
+    },
+    "ru": {
+        "tesseract": "rus",
+        "google": "ru"
+    },
+    "sa": {
+        "tesseract": "san",
+        "google": "sa"
+    },
+    "sd": {
+        "tesseract": "snd"
+    },
+    "si": {
+        "tesseract": "sin",
+        "google": "si"
+    },
+    "sk": {
+        "tesseract": "slk",
+        "google": "sk"
+    },
+    "sl": {
+        "tesseract": "slv",
+        "google": "sl"
+    },
+    "sq": {
+        "tesseract": "sqi",
+        "google": "sq"
+    },
+    "sr": {
+        "tesseract": "srp",
+        "google": "sr"
+    },
+    "sr-latn": {
+        "tesseract": "srp_latn",
+        "google": "sr-Latn"
+    },
+    "su": {
+        "tesseract": "sun",
+        "google": "su"
+    },
+    "sv": {
+        "tesseract": "swe",
+        "google": "sv"
+    },
+    "sw": {
+        "tesseract": "swa",
+        "google": "sw"
+    },
+    "syr": {
+        "tesseract": "syr",
+        "google": "syr"
+    },
+    "ta": {
+        "tesseract": "tam",
+        "google": "ta"
+    },
+    "te": {
+        "tesseract": "tel",
+        "google": "te"
+    },
+    "tg": {
+        "tesseract": "tgk",
+        "google": "tg"
+    },
+    "th": {
+        "tesseract": "tha",
+        "google": "th"
+    },
+    "ti": {
+        "tesseract": "tir",
+        "google": "ti"
+    },
+    "tl": {
+        "tesseract": "fil",
+        "google": "tl"
+    },
+    "to": {
+        "tesseract": "ton",
+        "google": "to"
+    },
+    "tr": {
+        "tesseract": "tur",
+        "google": "tr"
+    },
+    "tt": {
+        "tesseract": "tat",
+        "google": "tt"
+    },
+    "uk": {
+        "tesseract": "ukr",
+        "google": "uk"
+    },
+    "ug": {
+        "tesseract": "uig"
+    },
+    "uz": {
+        "tesseract": "uzb",
+        "google": "uz"
+    },
+    "uz-cyrl": {
+        "tesseract": "uzb_cyrl",
+        "google": "uz-Cyrl"
+    },
+    "vi": {
+        "tesseract": "vie",
+        "google": "vi"
+    },
+    "yi": {
+        "tesseract": "yid",
+        "google": "yi"
+    },
+    "yo": {
+        "tesseract": "yor",
+        "google": "yo"
+    },
+    "zh": {
+        "tesseract": "chi_sim",
+        "google": "zh"
+    },
+    "zh-hans": {
+        "tesseract": "chi_sim",
+        "google": "zh"
+    },
+    "zh-hant": {
+        "tesseract": "chi_tra",
+        "google": "zh"
+    },
+    "zu": {
+        "google": "zu"
+    }
+}

--- a/src/Controller/OcrController.php
+++ b/src/Controller/OcrController.php
@@ -64,7 +64,7 @@ class OcrController extends AbstractController
 
         // Engine.
         $this->engine = $engineFactory->get($request->get('engine', static::$params['engine']));
-        static::$params['engine'] = $this->engine instanceof TesseractEngine ? 'tesseract' : 'google';
+        static::$params['engine'] = $this->engine::getId();
 
         // Parameters.
         $this->imageUrl = (string)$request->query->get('image');
@@ -155,7 +155,7 @@ class OcrController extends AbstractController
     {
         return $this->getApiResponse([
             'engine' => static::$params['engine'],
-            'available_langs' => $this->engine->getValidLangs(),
+            'available_langs' => $this->engine->getValidLangs(true),
         ]);
     }
 

--- a/src/Engine/EngineBase.php
+++ b/src/Engine/EngineBase.php
@@ -17,12 +17,48 @@ abstract class EngineBase
     /** @var Intuition */
     protected $intuition;
 
-    public function __construct(Intuition $intuition)
+    /** @var string */
+    protected $projectDir;
+
+    /** @var string[][] Local PHP array copy of langs.json */
+    protected $langList;
+
+    /** @var string[] Additional localized names for non-standard language codes. */
+    public const LANG_NAMES = [
+        'az-cyrl' => 'Azərbaycan (qədim yazı)',
+        'de-frk' => 'Deutsch (Fraktur)',
+        'enm' => 'Middle English (1100-1500)',
+        'es-old' => 'español (viejo)',
+        'equ' => 'Math / equation detection module',
+        'fro' => 'Franceis, François, Romanz (1400-1600)',
+        'it-old' => 'italiano (vecchio)',
+        'ka-old' => 'ქართული (ძველი)',
+        'ko-vert' => '한국어 (세로)',
+        'osd' => 'Orientation and script detection module',
+        'sr-latn' => 'Српски (латиница)',
+        'syr' => 'leššānā Suryāyā',
+        'uz-cyrl' => 'oʻzbekcha',
+    ];
+
+    /**
+     * EngineBase constructor.
+     * @param Intuition $intuition
+     * @param string $projectDir
+     */
+    public function __construct(Intuition $intuition, string $projectDir)
     {
         $this->intuition = $intuition;
+        $this->projectDir = $projectDir;
     }
 
     /**
+     * Unique identifier for the engine.
+     * @return string
+     */
+    abstract public static function getId(): string;
+
+    /**
+     * Get transcribed text from the given image.
      * @param string $imageUrl
      * @param string[]|null $langs
      * @return string
@@ -30,16 +66,77 @@ abstract class EngineBase
     abstract public function getText(string $imageUrl, ?array $langs = null): string;
 
     /**
+     * Get the language list from langs.json
+     * @return string[][]
+     */
+    private function getLangList(): array
+    {
+        if (!$this->langList) {
+            $this->langList = json_decode(file_get_contents($this->projectDir.'/public/langs.json'), true);
+        }
+
+        return $this->langList;
+    }
+
+    /**
+     * Get languages accepted by the engine.
+     * @param bool $withNames Whether to include the localized language name.
+     * @return string[] ISO 639-1 codes, optionally as keys with language names as the values.
+     */
+    public function getValidLangs(bool $withNames = false): array
+    {
+        $langs = array_keys(array_filter($this->getLangList(), function ($values) {
+            return isset($values[static::getId()]);
+        }));
+
+        if (!$withNames) {
+            return $langs;
+        }
+
+        // Add the localized names for each language.
+        $list = [];
+        foreach ($langs as $lang) {
+            $list[$lang] = $this->getLangName($lang);
+        }
+
+        return $list;
+    }
+
+    /**
+     * Get the name of the given language. This adds a few translations that don't exist in Intuition.
+     * @param string|null $lang
+     * @return string
+     */
+    public function getLangName(?string $lang = null): string
+    {
+        return '' === $this->intuition->getLangName($lang)
+            ? (self::LANG_NAMES[$lang] ?? '')
+            : $this->intuition->getLangName($lang);
+    }
+
+    /**
+     * Transform the given ISO 639-1 codes into the language codes needed by this type of Engine.
+     * @param string[] $langs
      * @return string[]
      */
-    abstract public function getValidLangs(): array;
+    public function getLangCodes(array $langs): array
+    {
+        return array_map(function ($lang) {
+            return $this->getLangList()[$lang][static::getId()];
+        }, $langs);
+    }
 
+    /**
+     * Set the allowed image hosts.
+     * @param string $imageHosts
+     */
     public function setImageHosts(string $imageHosts): void
     {
         $this->imageHosts = array_map('trim', explode(',', $imageHosts));
     }
 
     /**
+     * Get the allowed image hosts.
      * @return string[]
      */
     public function getImageHosts(): array

--- a/src/Engine/GoogleCloudVisionEngine.php
+++ b/src/Engine/GoogleCloudVisionEngine.php
@@ -20,18 +20,25 @@ class GoogleCloudVisionEngine extends EngineBase
     /**
      * GoogleCloudVisionEngine constructor.
      * @param string $keyFile Filesystem path to the credentials JSON file.
+     * @param Intuition $intuition
+     * @param string $projectDir
      */
-    public function __construct(string $keyFile, Intuition $intuition)
+    public function __construct(string $keyFile, Intuition $intuition, string $projectDir)
     {
-        parent::__construct($intuition);
+        parent::__construct($intuition, $projectDir);
         $this->imageAnnotator = new ImageAnnotatorClient(['credentials' => $keyFile]);
     }
 
     /**
-     * Get transcribed text from the given image.
-     * @param string $imageUrl
-     * @param string[]|null $langs
-     * @return string
+     * @inheritDoc
+     */
+    public static function getId(): string
+    {
+        return 'google';
+    }
+
+    /**
+     * @inheritDoc
      * @throws OcrException
      */
     public function getText(string $imageUrl, ?array $langs = null): string
@@ -54,76 +61,5 @@ class GoogleCloudVisionEngine extends EngineBase
 
         $annotation = $response->getFullTextAnnotation();
         return $annotation instanceof TextAnnotation ? $annotation->getText() : '';
-    }
-
-    /**
-     * Get the valid language codes
-     * @return string[]
-     */
-    public function getValidLangs(): array
-    {
-        return [
-            "af",
-            "sq",
-            "ar",
-            "hy",
-            "be",
-            "bn",
-            "bg",
-            "ca",
-            "zh",
-            "hr",
-            "cs",
-            "da",
-            "nl",
-            "en",
-            "et",
-            "fil",
-            "tl",
-            "fi",
-            "fr",
-            "de",
-            "el",
-            "gu",
-            "iw",
-            "hi",
-            "hu",
-            "is",
-            "id",
-            "it",
-            "ja",
-            "kn",
-            "km",
-            "ko",
-            "lo",
-            "lv",
-            "lt",
-            "mk",
-            "ms",
-            "ml",
-            "mr",
-            "ne",
-            "no",
-            "fa",
-            "pl",
-            "pt",
-            "pa",
-            "ro",
-            "ru",
-            "ru-PETR1708",
-            "sr",
-            "sr-Latn",
-            "sk",
-            "sl",
-            "es",
-            "sv",
-            "ta",
-            "te",
-            "th",
-            "tr",
-            "uk",
-            "vi",
-            "yi",
-        ];
     }
 }

--- a/src/Engine/TesseractEngine.php
+++ b/src/Engine/TesseractEngine.php
@@ -29,17 +29,34 @@ class TesseractEngine extends EngineBase
     /** @var int Default value for OCR engine mode. */
     public const DEFAULT_OEM = 3;
 
-    public function __construct(HttpClientInterface $httpClient, Intuition $intuition, TesseractOCR $tesseractOcr)
-    {
-        parent::__construct($intuition);
+    /**
+     * TesseractEngine constructor.
+     * @param HttpClientInterface $httpClient
+     * @param Intuition $intuition
+     * @param string $projectDir
+     * @param TesseractOCR $tesseractOcr
+     */
+    public function __construct(
+        HttpClientInterface $httpClient,
+        Intuition $intuition,
+        string $projectDir,
+        TesseractOCR $tesseractOcr
+    ) {
+        parent::__construct($intuition, $projectDir);
         $this->httpClient = $httpClient;
         $this->ocr = $tesseractOcr;
     }
 
     /**
-     * @param string $imageUrl
-     * @param string[]|null $langs
-     * @return string
+     * @inheritDoc
+     */
+    public static function getId(): string
+    {
+        return 'tesseract';
+    }
+
+    /**
+     * @inheritDoc
      * @throws OcrException
      */
     public function getText(string $imageUrl, ?array $langs = null): string
@@ -68,15 +85,6 @@ class TesseractEngine extends EngineBase
         putenv('OMP_THREAD_LIMIT=1');
         $text = $this->ocr->run();
         return $text;
-    }
-
-    /**
-     * Get the valid language codes
-     * @return string[]
-     */
-    public function getValidLangs(): array
-    {
-        return $this->ocr->availableLanguages();
     }
 
     /**

--- a/src/Twig/AppExtension.php
+++ b/src/Twig/AppExtension.php
@@ -3,11 +3,36 @@ declare(strict_types = 1);
 
 namespace App\Twig;
 
+use App\Engine\TesseractEngine;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
+use Twig\TwigFunction;
 
 class AppExtension extends AbstractExtension
 {
+    /** @var TesseractEngine */
+    protected $engine;
+
+    /**
+     * AppExtension constructor.
+     * @param TesseractEngine $engine
+     */
+    public function __construct(TesseractEngine $engine)
+    {
+        $this->engine = $engine;
+    }
+
+    /**
+     * Registry of custom TwigFunctions.
+     * @return TwigFunction[]
+     */
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('ocr_lang_name', [$this, 'getOcrLangName']),
+        ];
+    }
+
     /**
      * Registry of custom TwigFilters.
      * @return TwigFilter[]
@@ -27,5 +52,15 @@ class AppExtension extends AbstractExtension
     public function getTextareaRows(string $text): int
     {
         return max(10, substr_count($text, "\n"));
+    }
+
+    /**
+     * Get the name of the given language. This adds a few translations that don't exist in Intuition.
+     * @param string|null $lang
+     * @return string
+     */
+    public function getOcrLangName(?string $lang = null): string
+    {
+        return $this->engine->getLangName($lang);
     }
 }

--- a/templates/_tesseract_options.html.twig
+++ b/templates/_tesseract_options.html.twig
@@ -1,4 +1,4 @@
-<fieldset id="tesseract-options" class="engine-options hidden">
+<fieldset id="tesseract-options" class="engine-options {% if engine != 'tesseract' %}hidden{% endif %}">
     <legend>{{ msg('tesseract-options') }}</legend>
     <div class="form-group">
         <label for="psm">{{ msg('tesseract-psm-label') }}</label>

--- a/templates/output.html.twig
+++ b/templates/output.html.twig
@@ -13,9 +13,9 @@
                 {% for lang in available_langs %}
                     <option value="{{ lang }}" {% if lang in langs %}selected{% endif %}>
                         {{ lang }}
-                        {% if lang_name(lang) is not empty %}
+                        {% if ocr_lang_name(lang) is not empty %}
                             &ndash;
-                            {{ lang_name(lang) }}
+                            {{ ocr_lang_name(lang) }}
                         {% endif %}
                     </option>
                 {% endfor %}
@@ -30,7 +30,7 @@
             </select>
             <p class="help-block">{{ msg( 'engine-help' ) }}</p>
         </div>
-        {% include '_tesseract_options.html.twig' %}
+        {% include '_tesseract_options.html.twig' with {engine: engine} %}
         <div class="form-group">
             <input type="submit" value="{{ msg( 'submit' ) }}" class="btn btn-info" />
         </div>

--- a/tests/Controller/OcrControllerTest.php
+++ b/tests/Controller/OcrControllerTest.php
@@ -7,15 +7,15 @@ use App\Controller\OcrController;
 use App\Engine\EngineFactory;
 use App\Engine\GoogleCloudVisionEngine;
 use App\Engine\TesseractEngine;
+use App\Tests\OcrTestCase;
 use Krinkle\Intuition\Intuition;
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use thiagoalessio\TesseractOCR\TesseractOCR;
 
-class OcrControllerTest extends TestCase
+class OcrControllerTest extends OcrTestCase
 {
 
     /**
@@ -29,11 +29,18 @@ class OcrControllerTest extends TestCase
         $requestStack = new RequestStack();
         $requestStack->push($request);
         $intuition = new Intuition([]);
-        $gcv = new GoogleCloudVisionEngine(dirname(__DIR__).'/fixtures/google-account-keyfile.json', $intuition);
+        $gcv = new GoogleCloudVisionEngine(
+            dirname(__DIR__).'/fixtures/google-account-keyfile.json',
+            $intuition,
+            $this->projectDir
+        );
         $controller = new OcrController(
             $requestStack,
             $intuition,
-            new EngineFactory($gcv, new TesseractEngine(new MockHttpClient(), $intuition, new TesseractOCR())),
+            new EngineFactory(
+                $gcv,
+                new TesseractEngine(new MockHttpClient(), $intuition, $this->projectDir, new TesseractOCR())
+            ),
             new FilesystemAdapter()
         );
         $this->assertSame($expectedLangs, $controller->getLangs($request));

--- a/tests/OcrTestCase.php
+++ b/tests/OcrTestCase.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types = 1);
+
+namespace App\Tests;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class OcrTestCase extends KernelTestCase
+{
+    /** @var string */
+    protected $projectDir;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->projectDir = self::$kernel->getProjectDir();
+    }
+}

--- a/tests/Twig/AppExtensionTest.php
+++ b/tests/Twig/AppExtensionTest.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types = 1);
+
+namespace App\Tests\Twig;
+
+use App\Engine\TesseractEngine;
+use App\Tests\OcrTestCase;
+use App\Twig\AppExtension;
+use Krinkle\Intuition\Intuition;
+use Symfony\Component\HttpClient\MockHttpClient;
+use thiagoalessio\TesseractOCR\TesseractOCR;
+
+class AppExtensionTest extends OcrTestCase
+{
+    /** @var AppExtension */
+    protected $ext;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $engine = new TesseractEngine(new MockHttpClient(), new Intuition(), $this->projectDir, new TesseractOCR());
+        $this->ext = new AppExtension($engine);
+    }
+
+    /**
+     * @covers AppExtension::getOcrLangName
+     */
+    public function testOcrLangName(): void
+    {
+        // Non-standard language code with name defined in EngineBase::LANG_NAMES
+        static::assertSame('Azərbaycan (qədim yazı)', $this->ext->getOcrLangName('az-cyrl'));
+
+        // Standard language code (name provided by Intuition)
+        static::assertSame('English', $this->ext->getOcrLangName('en'));
+    }
+}


### PR DESCRIPTION
This also adds the extra non-standard languages offered by Tesseract,
along with their localized names.
    
The Select2 control on the form now dynamically updates with the
supported languages when the engine is changed.
    
Bug: https://phabricator.wikimedia.org/T282760
Bug: https://phabricator.wikimedia.org/T281866
Bug: https://phabricator.wikimedia.org/T282073