### PR TITLE
Tranform lang codes before passing to engine

### DIFF
--- a/src/Engine/GoogleCloudVisionEngine.php
+++ b/src/Engine/GoogleCloudVisionEngine.php
@@ -50,7 +50,7 @@ class GoogleCloudVisionEngine extends EngineBase
 
         $imageContext = new ImageContext();
         if (null !== $langs) {
-            $imageContext->setLanguageHints($langs);
+            $imageContext->setLanguageHints($this->getLangCodes($langs));
         }
 
         $response = $this->imageAnnotator->textDetection($imageUrl, ['imageContext' => $imageContext]);

--- a/src/Engine/TesseractEngine.php
+++ b/src/Engine/TesseractEngine.php
@@ -73,9 +73,10 @@ class TesseractEngine extends EngineBase
         } catch (ClientException $exception) {
             throw new OcrException('image-retrieval-failed', [$exception->getMessage()]);
         }
+
         $this->ocr->imageData($imageContent, $imageResponse->getHeaders()['content-length'][0]);
         if ($langs && count($langs) > 0) {
-            $this->ocr->lang(...$langs);
+            $this->ocr->lang(...$this->getLangCodes($langs));
         }
 
         // Env vars are passed through by the thiagoalessio/tesseract_ocr package to the tesseract command,


### PR DESCRIPTION
In #33 we allowed the user to enter ISO 639-1 codes, but we didn't use
EngineBase::getLangCodes() when actually setting the language, meaning
the language codes don't get transformed properly for the engine.

Bug: T282760
Bug: T282073