### PR TITLE
Catch all internal exceptions from tesseract

### DIFF
--- a/config/packages/dev/monolog.yaml
+++ b/config/packages/dev/monolog.yaml
@@ -1,4 +1,5 @@
 monolog:
+    channels: ['main', 'console', 'tesseract']
     handlers:
         main:
             type: stream
@@ -17,3 +18,7 @@ monolog:
             type: console
             process_psr_3_messages: false
             channels: ["!event", "!doctrine", "!console"]
+        tesseract:
+            type: fingers_crossed
+            action_level: error
+            handler: console

--- a/config/packages/prod/monolog.yaml
+++ b/config/packages/prod/monolog.yaml
@@ -1,4 +1,5 @@
 monolog:
+    channels: ['main', 'tesseract']
     handlers:
         main:
             type: fingers_crossed
@@ -29,3 +30,7 @@ monolog:
             subject: '%env(APP_LOG_SUBJECT)% %%message%%'
             formatter: monolog.formatter.html
             content_type: text/html
+        tesseract:
+            type: fingers_crossed
+            action_level: error
+            handler: nested

--- a/config/packages/test/monolog.yaml
+++ b/config/packages/test/monolog.yaml
@@ -1,4 +1,5 @@
 monolog:
+    channels: ['main', 'nested', 'tesseract']
     handlers:
         main:
             type: fingers_crossed
@@ -10,3 +11,7 @@ monolog:
             type: stream
             path: "%kernel.logs_dir%/%kernel.environment%.log"
             level: debug
+        tesseract:
+            type: fingers_crossed
+            action_level: error
+            handler: nested

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -48,6 +48,7 @@ services:
             - '@session'
             - '@twig'
             - '@Krinkle\Intuition\Intuition'
+            - '@monolog.logger.tesseract'
         tags:
             - { name: kernel.event_listener, event: kernel.exception }
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -41,5 +41,6 @@
     "tesseract-oem-1": "Neural nets LSTM engine only.",
     "tesseract-oem-2": "Legacy + LSTM engines.",
     "tesseract-oem-3": "Default, based on what is available.",
-    "tesseract-param-error": "The '$1' option with a value of $2 is not supported by Tesseract. Maximum value: $3"
+    "tesseract-param-error": "The '$1' option with a value of $2 is not supported by Tesseract. Maximum value: $3",
+	"tesseract-internal-error": "The tesseract engine returned an internal error."
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -42,5 +42,5 @@
     "tesseract-oem-2": "Legacy + LSTM engines.",
     "tesseract-oem-3": "Default, based on what is available.",
     "tesseract-param-error": "The '$1' option with a value of $2 is not supported by Tesseract. Maximum value: $3",
-	"tesseract-internal-error": "The tesseract engine returned an internal error."
+    "tesseract-internal-error": "The tesseract engine returned an internal error."
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -45,5 +45,6 @@
 	"tesseract-oem-1": "Form option for Tesseract OCR engine mode.",
 	"tesseract-oem-2": "Form option for Tesseract OCR engine mode.",
 	"tesseract-oem-3": "Form option for Tesseract OCR engine mode.",
-	"tesseract-param-error": "Error message displayed when invalid values for Tesseract options are submitted.\n\nParameters:\n* $1 – the form label for the option. This will either be {{msg-wm|tesseract-psm-label}} or {{msg-wm|tesseract-oem-label}}.\n* $2 – The value that was given.\n* $3 – the maximum value for the option (this will be an integer)."
+	"tesseract-param-error": "Error message displayed when invalid values for Tesseract options are submitted.\n\nParameters:\n* $1 – the form label for the option. This will either be {{msg-wm|tesseract-psm-label}} or {{msg-wm|tesseract-oem-label}}.\n* $2 – The value that was given.\n* $3 – the maximum value for the option (this will be an integer).",
+	"tesseract-internal-error": "Generic error message displayed when the tesseract command fails."
 }

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -6,6 +6,7 @@ namespace App\EventListener;
 use App\Controller\OcrController;
 use App\Exception\OcrException;
 use Krinkle\Intuition\Intuition;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -13,7 +14,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
-use thiagoalessio\TesseractOCR\TesseractOcrException;
+use thiagoalessio\TesseractOCR\UnsuccessfulCommandException;
 use Twig\Environment;
 
 class ExceptionListener
@@ -30,24 +31,29 @@ class ExceptionListener
     /** @var Intuition */
     private $intuition;
 
+    /** @var LoggerInterface */
+    private $tesseractLogger;
+
     public function __construct(
         RequestStack $requestStack,
         SessionInterface $session,
         Environment $twig,
-        Intuition $intuition
+        Intuition $intuition,
+        LoggerInterface $tesseractLogger
     ) {
         $this->request = $requestStack->getCurrentRequest();
         $this->session = $session;
         $this->twig = $twig;
         $this->intuition = $intuition;
+        $this->tesseractLogger = $tesseractLogger;
     }
 
     public function onKernelException(ExceptionEvent $event): void
     {
         $exception = $event->getThrowable();
 
-        // We only care about OcrExceptions, and TesseractOcrException thrown by the library (T282141).
-        if (!( $exception instanceof OcrException || $exception instanceof TesseractOcrException )
+        // We only care about OcrExceptions, and UnsuccessfulCommandException thrown by the library (T282141).
+        if (!( $exception instanceof OcrException || $exception instanceof UnsuccessfulCommandException )
             || !$event->isMasterRequest()
         ) {
             return;
@@ -58,9 +64,15 @@ class ExceptionListener
             OcrController::$params,
             $this->request->query->all()
         );
-        $errorMessage = $exception instanceof TesseractOcrException
-            ? $this->getMessageForTesseractException($exception)
-            : $this->intuition->msg($exception->getI18nKey(), ['variables' => $exception->getI18nParams()]);
+        if ($exception instanceof UnsuccessfulCommandException) {
+            $this->tesseractLogger->critical($exception->__toString());
+            $errorMessage = $this->getMessageForTesseractException($exception);
+        } else {
+            $errorMessage = $this->intuition->msg(
+                $exception->getI18nKey(),
+                ['variables' => $exception->getI18nParams()]
+            );
+        }
 
         if ($isApi) {
             $params['error'] = $errorMessage;
@@ -84,10 +96,10 @@ class ExceptionListener
      * being helpful and not giving away any potentially sensitive information (as might happen if we were
      * to pass any error message through).
      *
-     * @param TesseractOcrException $exc @phan-unused-param
+     * @param UnsuccessfulCommandException $exc @phan-unused-param
      * @return string
      */
-    private function getMessageForTesseractException(TesseractOcrException $exc) : string
+    private function getMessageForTesseractException(UnsuccessfulCommandException $exc) : string
     {
         // TODO: How can we be more specific about what's gone wrong?
         return $this->intuition->msg('tesseract-internal-error');

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -47,8 +47,7 @@ class ExceptionListener
         $exception = $event->getThrowable();
 
         // We only care about OcrExceptions, and TesseractOcrException thrown by the library (T282141).
-        if (
-            !( $exception instanceof OcrException || $exception instanceof TesseractOcrException )
+        if (!( $exception instanceof OcrException || $exception instanceof TesseractOcrException )
             || !$event->isMasterRequest()
         ) {
             return;
@@ -60,7 +59,7 @@ class ExceptionListener
             $this->request->query->all()
         );
         $errorMessage = $exception instanceof TesseractOcrException
-            ? $this->getMessageForTesseractException( $exception )
+            ? $this->getMessageForTesseractException($exception)
             : $this->intuition->msg($exception->getI18nKey(), ['variables' => $exception->getI18nParams()]);
 
         if ($isApi) {
@@ -80,16 +79,17 @@ class ExceptionListener
         $event->setResponse($response);
     }
 
-	/**
-	 * Given a tesseract-specific exception, try and extract a useful error message. Tries to balance between
-	 * being helpful and not giving away any potentially sensitive information (as might happen if we were
-	 * to pass any error message through).
-	 *
-	 * @param TesseractOcrException $exc @phan-unused-param
-	 * @return string
-	 */
-    private function getMessageForTesseractException( TesseractOcrException $exc ) : string {
+    /**
+     * Given a tesseract-specific exception, try and extract a useful error message. Tries to balance between
+     * being helpful and not giving away any potentially sensitive information (as might happen if we were
+     * to pass any error message through).
+     *
+     * @param TesseractOcrException $exc @phan-unused-param
+     * @return string
+     */
+    private function getMessageForTesseractException(TesseractOcrException $exc) : string
+    {
         // TODO: How can we be more specific about what's gone wrong?
-        return $this->intuition->msg( 'tesseract-internal-error' );
-	}
+        return $this->intuition->msg('tesseract-internal-error');
+    }
 }


### PR DESCRIPTION
For now, this uses a generic error message as it's not easy to be
informative without risking to output sensitive system info.

Bug: T282141