### PR TITLE
Add a test for special chars in language names

### DIFF
--- a/tests/Controller/OcrControllerTest.php
+++ b/tests/Controller/OcrControllerTest.php
@@ -60,6 +60,10 @@ class OcrControllerTest extends OcrTestCase
                 ['langs' => ['a|b', 'c!', 'ab']],
                 ['ab', 'c'],
             ],
+            'special characters' => [
+                ['langs' => ['sr-Latn', 'Canadian_Aboriginal']],
+                ['sr-Latn', 'Canadian_Aboriginal'],
+            ],
         ];
     }
 }


### PR DESCRIPTION
Follow-up of commit 5013405a821b0875de15700ddab812eb273c13be.

Bug: T281866