### PR TITLE
Tweak italian translation of "old italian"

### DIFF
--- a/src/Engine/EngineBase.php
+++ b/src/Engine/EngineBase.php
@@ -31,7 +31,7 @@ abstract class EngineBase
         'es-old' => 'español (viejo)',
         'equ' => 'Math / equation detection module',
         'fro' => 'Franceis, François, Romanz (1400-1600)',
-        'it-old' => 'italiano (vecchio)',
+        'it-old' => 'italiano antico',
         'ka-old' => 'ქართული (ძველი)',
         'ko-vert' => '한국어 (세로)',
         'osd' => 'Orientation and script detection module',


### PR DESCRIPTION
The common way of saying it is "italiano antico" (lit. "ancient"). The
sense is the same, but this sounds more natural.