### PR TITLE
Strengthen the configuration options for phan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
       with:
         php-version: ${{matrix.php}}
         coverage: none
+        extensions: ast
 
     - name: Install wikimedia-ocr
       run: |

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -2,52 +2,16 @@
 
 declare(strict_types = 1);
 
-/**
- * This configuration will be read and overlaid on top of the
- * default configuration. Command-line arguments will be applied
- * after this file is read.
- */
 return [
-    // Supported values: `'5.6'`, `'7.0'`, `'7.1'`, `'7.2'`, `'7.3'`,
-    // `'7.4'`, `null`.
-    // If this is set to `null`,
-    // then Phan assumes the PHP version which is closest to the minor version
-    // of the php executable used to execute Phan.
-    //
-    // Note that the **only** effect of choosing `'5.6'` is to infer
-    // that functions removed in php 7.0 exist.
-    // (See `backward_compatibility_checks` for additional options)
     'target_php_version' => null,
 
-    // A list of directories that should be parsed for class and
-    // method information. After excluding the directories
-    // defined in exclude_analysis_directory_list, the remaining
-    // files will be statically analyzed for errors.
-    //
-    // Thus, both first-party and third-party code being used by
-    // your application should be included in this list.
     'directory_list' => [
         'src',
         'vendor',
     ],
 
-    // A regex used to match every file name that you want to
-    // exclude from parsing. Actual value will exclude every
-    // "test", "tests", "Test" and "Tests" folders found in
-    // "vendor/" directory.
     'exclude_file_regex' => '@^vendor/.*/(tests?|Tests?)/@',
 
-    // A directory list that defines files that will be excluded
-    // from static analysis, but whose class and method
-    // information should be included.
-    //
-    // Generally, you'll want to include the directories for
-    // third-party code (such as "vendor/") in this list.
-    //
-    // n.b.: If you'd like to parse but not analyze 3rd
-    //       party code, directories containing that code
-    //       should be added to both the `directory_list`
-    //       and `exclude_analysis_directory_list` arrays.
     'exclude_analysis_directory_list' => [
         'vendor/',
     ],
@@ -58,5 +22,6 @@ return [
 
     'plugins' => [
         'vendor/drenso/phan-extensions/Plugin/Annotation/SymfonyAnnotationPlugin.php',
+        'vendor/mediawiki/phan-taint-check-plugin/GenericSecurityCheckPlugin.php'
     ],
 ];

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -18,10 +18,31 @@ return [
 
     'suppress_issue_types' => [
         'PhanUnreferencedUseNormal', // PHPCS does this already and without false positives.
+        'SecurityCheck-LikelyFalsePositive',
     ],
 
+    'enable_extended_internal_return_type_plugins' => true,
+    'generic_types_enabled' => true,
+
+    'null_casts_as_any_type' => false,
+    'scalar_implicit_cast' => false,
+    // Note: dead code detection has false positives with symfony magic methods
+
+    'redundant_condition_detection' => true,
+
     'plugins' => [
+        'UnreachableCodePlugin',
+        'PregRegexCheckerPlugin',
+        'UnusedSuppressionPlugin',
+        'DuplicateArrayKeyPlugin',
+        'DuplicateExpressionPlugin',
+        'RedundantAssignmentPlugin',
+        'StrictLiteralComparisonPlugin',
+        'DollarDollarPlugin',
+        'LoopVariableReusePlugin',
+        'StrictComparisonPlugin',
+        'SimplifyExpressionPlugin',
         'vendor/drenso/phan-extensions/Plugin/Annotation/SymfonyAnnotationPlugin.php',
-        'vendor/mediawiki/phan-taint-check-plugin/GenericSecurityCheckPlugin.php'
+        'vendor/mediawiki/phan-taint-check-plugin/GenericSecurityCheckPlugin.php',
     ],
 ];

--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,8 @@
     "require-dev": {
         "drenso/phan-extensions": "^3.3",
         "mediawiki/minus-x": "^1.1",
-        "phan/phan": "3.2.6",
         "mediawiki/phan-taint-check-plugin": "3.2.1",
+        "phan/phan": "3.2.6",
         "slevomat/coding-standard": "^4.8",
         "symfony/phpunit-bridge": "^5.2",
         "symfony/stopwatch": "^5.2",

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
     "require-dev": {
         "drenso/phan-extensions": "^3.3",
         "mediawiki/minus-x": "^1.1",
-        "phan/phan": "^4.0",
+        "phan/phan": "3.2.6",
+        "mediawiki/phan-taint-check-plugin": "3.2.1",
         "slevomat/coding-standard": "^4.8",
         "symfony/phpunit-bridge": "^5.2",
         "symfony/stopwatch": "^5.2",

--- a/composer.json
+++ b/composer.json
@@ -78,7 +78,7 @@
             "./bin/console lint:twig ./templates",
             "./bin/console lint:yaml ./config",
             "minus-x check .",
-            "phan --allow-polyfill-parser",
+            "phan --allow-polyfill-parser --long-progress-bar",
             "./bin/phpunit"
         ]
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d08d7034eeb0343aabdff24cd6cf7c72",
+    "content-hash": "3d7d52765d21f7e14fed7bc53af09413",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -6075,6 +6075,76 @@
             "time": "2021-01-06T01:11:18+00:00"
         },
         {
+            "name": "mediawiki/phan-taint-check-plugin",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wikimedia/phan-taint-check-plugin.git",
+                "reference": "4bc471bd790644398a6749eedd7a841e9a759bd6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wikimedia/phan-taint-check-plugin/zipball/4bc471bd790644398a6749eedd7a841e9a759bd6",
+                "reference": "4bc471bd790644398a6749eedd7a841e9a759bd6",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "phan/phan": "3.2.6",
+                "php": "^7.2.0 | ^8.0.0"
+            },
+            "require-dev": {
+                "mediawiki/mediawiki-codesniffer": "34.0.0",
+                "mediawiki/minus-x": "1.1.0",
+                "php-parallel-lint/php-console-highlighter": "0.5.0",
+                "php-parallel-lint/php-parallel-lint": "1.2.0",
+                "phpunit/phpunit": "^8.5"
+            },
+            "bin": [
+                "scripts/seccheck-mwext",
+                "scripts/seccheck-slow-mwext",
+                "scripts/seccheck-fast-mwext",
+                "scripts/seccheck-mw",
+                "scripts/seccheck-generic"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "SecurityCheckPlugin\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Brian Wolff",
+                    "email": "bawolff+wn@gmail.com"
+                },
+                {
+                    "name": "Daimona Eaytoy",
+                    "email": "daimona.wiki@gmail.com"
+                }
+            ],
+            "description": "A Phan plugin to do security checking",
+            "keywords": [
+                "analyzer",
+                "phan",
+                "php",
+                "security",
+                "static",
+                "taint"
+            ],
+            "support": {
+                "irc": "irc://freenode.net/wikimedia-dev",
+                "issues": "https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projects=securitycheckplugin",
+                "source": "https://phabricator.wikimedia.org/diffusion/MTPS/",
+                "wiki": "https://www.mediawiki.org/wiki/SecurityCheckPlugin"
+            },
+            "time": "2020-12-14T11:11:43+00:00"
+        },
+        {
             "name": "microsoft/tolerant-php-parser",
             "version": "v0.0.23",
             "source": {
@@ -6163,16 +6233,16 @@
         },
         {
             "name": "phan/phan",
-            "version": "4.0.3",
+            "version": "3.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phan/phan.git",
-                "reference": "95171b8a89ff2433e7ebc27d8a133743f7d78d3b"
+                "reference": "e14110d4bef8643562b02a4003015c2c0dcc9fe4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phan/phan/zipball/95171b8a89ff2433e7ebc27d8a133743f7d78d3b",
-                "reference": "95171b8a89ff2433e7ebc27d8a133743f7d78d3b",
+                "url": "https://api.github.com/repos/phan/phan/zipball/e14110d4bef8643562b02a4003015c2c0dcc9fe4",
+                "reference": "e14110d4bef8643562b02a4003015c2c0dcc9fe4",
                 "shasum": ""
             },
             "require": {
@@ -6194,7 +6264,7 @@
                 "phpunit/phpunit": "^8.5.0"
             },
             "suggest": {
-                "ext-ast": "Needed for parsing ASTs (unless --use-fallback-parser is used). 1.0.1+ is needed, 1.0.10+ is recommended.",
+                "ext-ast": "Needed for parsing ASTs (unless --use-fallback-parser is used). 1.0.1+ is needed, 1.0.8+ is recommended.",
                 "ext-iconv": "Either iconv or mbstring is needed to ensure issue messages are valid utf-8",
                 "ext-igbinary": "Improves performance of polyfill when ext-ast is unavailable",
                 "ext-mbstring": "Either iconv or mbstring is needed to ensure issue messages are valid utf-8",
@@ -6232,7 +6302,11 @@
                 "php",
                 "static"
             ],
-            "time": "2021-01-30T00:08:54+00:00"
+            "support": {
+                "issues": "https://github.com/phan/phan/issues",
+                "source": "https://github.com/phan/phan/tree/3.2.6"
+            },
+            "time": "2020-11-27T19:39:49+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -6823,5 +6897,5 @@
     "platform-overrides": {
         "php": "7.2.31"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/symfony.lock
+++ b/symfony.lock
@@ -110,6 +110,9 @@
     "mediawiki/oauthclient": {
         "version": "1.1.0"
     },
+    "mediawiki/phan-taint-check-plugin": {
+        "version": "3.2.1"
+    },
     "microsoft/tolerant-php-parser": {
         "version": "v0.0.23"
     },
@@ -348,6 +351,9 @@
     },
     "symfony/polyfill-php80": {
         "version": "v1.22.1"
+    },
+    "symfony/polyfill-php81": {
+        "version": "v1.23.0"
     },
     "symfony/process": {
         "version": "v5.2.4"


### PR DESCRIPTION
- Add phan-taint-check-plugin to spot possible security issues (although it still cannot understand templates)
- Pass --long-progress-bar explicitly to make sure the progress bar it's always shown
- Add a few config options for stricter analysis. This is a good set of options, and doesn't cause any new issue to be reported
- Install the php-ast extension in the github CI to run phan faster

Note that we need to downgrade phan due to the strict dependency that taint-check has.

Bug: T284571