### PR TITLE
Avoid extra whitespace in select options

### DIFF
--- a/templates/output.html.twig
+++ b/templates/output.html.twig
@@ -12,11 +12,7 @@
             <select id="lang" class="form-control" name="langs[]" multiple>
                 {% for lang in available_langs %}
                     <option value="{{ lang }}" {% if lang in langs %}selected{% endif %}>
-                        {{ lang }}
-                        {% if ocr_lang_name(lang) is not empty %}
-                            &ndash;
-                            {{ ocr_lang_name(lang) }}
-                        {% endif %}
+                        {{- lang }}{% if ocr_lang_name(lang) is not empty %} &ndash; {{ ocr_lang_name(lang) }}{% endif -%}
                     </option>
                 {% endfor %}
             </select>


### PR DESCRIPTION
The formatting whitespace was actually being kept in the final HTML, thus eventually creating `title` attributes full of spaces.

Bug: T284654