### PR TITLE
Exclude 'equ' from the list of available languages

### DIFF
--- a/public/langs.json
+++ b/public/langs.json
@@ -104,9 +104,6 @@
         "tesseract": "epo",
         "google": "eo"
     },
-    "equ": {
-        "tesseract": "equ"
-    },
     "es": {
         "tesseract": "spa",
         "google": "es"

--- a/tests/Engine/EngineBaseTest.php
+++ b/tests/Engine/EngineBaseTest.php
@@ -84,16 +84,31 @@ class EngineBaseTest extends OcrTestCase
     }
 
     /**
+     * @param string[] $langs Language codes
+     * @param bool $valid
      * @covers EngineBase::validateLangs for Tesseract Engine
+     * @dataProvider provideTesseractLangs
      */
-    public function testValidateLangsTesseractEngine(): void
+    public function testValidateLangsTesseractEngine(array $langs, bool $valid): void
     {
-        // Should not throw an exception.
-        $this->tesseractEngine->validateLangs(['en', 'fr']);
+        if (!$valid) {
+            $this->expectException(OcrException::class);
+        }
+        $this->tesseractEngine->validateLangs($langs);
+        $this->addToAssertionCount(1);
+    }
 
-        // Should throw an exception. `foo` is not a valid lang
-        static::expectException(OcrException::class);
-        $this->tesseractEngine->validateLangs(['foo', 'fr']);
+    /**
+     * @return array<array<string[]|bool>>
+     */
+    public function provideTesseractLangs(): array
+    {
+        return [
+            'valid' => [ [ 'en', 'fr' ], true ],
+            'invalid' => [ [ 'foo', 'fr' ], false ],
+            // 'equ' is excluded on purpose: T284827
+            'intentionally excluded' => [ [ 'equ' ], false ],
+        ];
     }
 
     /**


### PR DESCRIPTION
It is not included by default, because it basically only produces gibberish.

Bug: T284827