### PR TITLE
Add Google lang code for Punjabi (pa)

### DIFF
--- a/public/langs.json
+++ b/public/langs.json
@@ -327,7 +327,7 @@
     },
     "pa": {
         "tesseract": "pan",
-        "google": ""
+        "google": "pa"
     },
     "pl": {
         "tesseract": "pol",


### PR DESCRIPTION
It's listed as supported in the Google list:
https://cloud.google.com/vision/docs/languages