### PR TITLE
Ignore invalid languages for API requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,9 @@ The [documentation](https://cloud.google.com/vision/reference/rest/v1/images/ann
 > For languages based on the Latin alphabet, setting languageHints is not needed.
 > In rare cases, when the language of the text in the image is known, setting a hint will help get better results
 > (although it will be a significant hindrance if the hint is wrong).
-> Text detection returns an error if one or more of the specified languages is not
-> one of the [supported languages](https://cloud.google.com/vision/docs/languages).
+> Text detection via the web interface returns an error if one or more of the specified languages is not
+> one of the [supported languages](https://cloud.google.com/vision/docs/languages). API requests will succeed
+> with a warning reporting invalid languages.
 
 #### Tesseract
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -12,6 +12,7 @@
     "engine-name-google": "Google Cloud Vision OCR",
     "engine-name-tesseract": "Tesseract OCR",
     "engine-not-found-warning": "The requested engine '$1' was not found. Using the default engine '$2' instead.",
+	"engine-invalid-langs-warning": "The following languages are invalid or not supported by the engine and were ignored: $1",
     "submit": "Transcribe",
     "copy-to-clipboard": "Copy to clipboard",
     "copied-to-clipboard": "Copied!",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -17,6 +17,7 @@
 	"engine-name-google": "Option text for the 'google' engine.",
 	"engine-name-tesseract": "Option text for the 'tesseract' engine.",
 	"engine-not-found-warning": "Error message displayed when an invalid engine is requested.\n\nParameter:\n* $1 – the requested engine.\n* $2 – the default engine that is being used instead.",
+	"engine-invalid-langs-warning": "Warning message displayed when invalid or unsupported languages are requested.\n\nParameter:\n* $1 – a comma-separated list of invalid languages.",
 	"submit": "Submit button text.\n{{identical|Go}}",
 	"copy-to-clipboard": "Button text for the copy-to-clipboard button.",
 	"copied-to-clipboard": "Button text shown after the copy-to-clipboard button is clicked.",

--- a/src/Engine/EngineResult.php
+++ b/src/Engine/EngineResult.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types = 1);
+
+namespace App\Engine;
+
+/**
+ * Immutable and serializable value object that represents the result (output) of an OCR engine operation
+ */
+class EngineResult
+{
+    /** @var string */
+    private $text;
+
+    /** @var string[] */
+    private $warnings;
+
+    /**
+     * @param string $text
+     * @param string[] $warnings
+     */
+    public function __construct(string $text, array $warnings = [])
+    {
+        $this->text = $text;
+        $this->warnings = $warnings;
+    }
+
+    /**
+     * @return string
+     */
+    public function getText(): string
+    {
+        return $this->text;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getWarnings(): array
+    {
+        return $this->warnings;
+    }
+}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -33,6 +33,13 @@
                     </div>
                 {% endfor %}
             {% endfor %}
+            {% for label, messages in app.flashes(['warning']) %}
+                {% for message in messages %}
+                    <div class="alert alert-warning">
+                        {{ message }}
+                    </div>
+                {% endfor %}
+            {% endfor %}
 
             {% block body %}{% endblock %}
 


### PR DESCRIPTION
**NEW:**
Instead of failing hard with an exception, we add a warning to the
response.
This is mainly useful for requests from wikisource, where we pass the
content language by default, but it might be unsupported.

Also make the engines return structured output and add code for
supporting warnings even in the UI, although it's currently impossible
to get any.

Bug: T285544

**OLD:**
This is only useful for requests from wikisource, where we pass the
content language by default, but it might be unsupported. As such, this
option is not exposed in the UI.

Bug: T285544