### PR TITLE
Move textarea height to CSS only

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -64,9 +64,4 @@ $(function () {
             $copyButton.text($copyButton.data('copied-text'));
         });
     }
-
-    // Make textarea match height of image.
-    $('#text').css({
-        height: $('#source-image').outerHeight(),
-    });
 });

--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -69,8 +69,29 @@ fieldset,
 	margin-top: 40px;
 }
 
+.image-row-outer {
+	position: relative;
+}
+
 .copy-button {
 	position: absolute;
+	/* Relative to .image-row-outer above. */
 	right: 30px;
 	top: 15px;
+}
+
+.image-row {
+	display: flex;
+}
+
+.image-row .image {
+	flex: 1;
+	margin-right: 0.5em;
+}
+
+.image-row .text {
+	flex: 1;
+	/* Flexbox here to stretch textarea (the only child of .text) to full height. */
+	display: flex;
+	margin-left: 0.5em;
 }

--- a/templates/output.html.twig
+++ b/templates/output.html.twig
@@ -45,14 +45,16 @@
 
     {% if text is defined %}
         <hr/>
-        <div class="row">
-            <div class="col-md-6">
-                <img id="source-image" class="img-responsive" src="{{ app.request.get('image') }}" alt="{{ msg('img-alt-text') }}" />
+        <div class="image-row-outer">
+            <div class="image-row">
+                <div class="image">
+                    <img id="source-image" class="img-responsive" src="{{ app.request.get('image') }}" alt="{{ msg('img-alt-text') }}" />
+                </div>
+                <div class="text">
+                    <textarea class="form-control" rows="{{ text|textarea_rows }}" id="text">{{ text }}</textarea>
+                </div>
             </div>
-            <div class="col-md-6">
-                <button class="btn btn-info copy-button" data-copied-text="{{ msg('copied-to-clipboard') }}">{{ msg( 'copy-to-clipboard' ) }}</button>
-                <textarea class="form-control" rows="{{ text|textarea_rows }}" id="text">{{ text }}</textarea>
-            </div>
+            <button class="btn btn-info copy-button" data-copied-text="{{ msg('copied-to-clipboard') }}">{{ msg( 'copy-to-clipboard' ) }}</button>
         </div>
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
Rather than using JS to resize the textarea (which can fail if
the image takes too long to load), do it in CSS with flexbox.

Bug: T288190