### PR TITLE
Allow protocol relative URLs for the image

### DIFF
--- a/src/Engine/EngineBase.php
+++ b/src/Engine/EngineBase.php
@@ -175,7 +175,7 @@ abstract class EngineBase
     {
         $hostRegex = implode('|', array_map('preg_quote', $this->getImageHosts()));
         $formatRegex = implode('|', self::ALLOWED_FORMATS);
-        $regex = "/https?:\/\/($hostRegex)\/.+($formatRegex)$/";
+        $regex = "/(https?:)?\/\/($hostRegex)\/.+($formatRegex)$/";
         $matches = preg_match($regex, strtolower($imageUrl));
         if (1 !== $matches) {
             $params = [count($this->getImageHosts()), $this->intuition->listToText($this->getImageHosts())];

--- a/templates/output.html.twig
+++ b/templates/output.html.twig
@@ -6,7 +6,7 @@
             <legend>{{ msg('form-heading') }}</legend>
             <div class="form-group">
                 <label for="image">{{ msg('image-url') }}</label>
-                <input name="image" id="image" class="form-control" type="url" value="{{ app.request.get('image') }}" required />
+                <input name="image" id="image" class="form-control" type="url" value="{{ image }}" required />
                 <p class="help-block">{{ msg( 'image-url-help', [image_hosts] ) }}</p>
             </div>
             <div class="form-group">

--- a/tests/Engine/EngineBaseTest.php
+++ b/tests/Engine/EngineBaseTest.php
@@ -66,6 +66,7 @@ class EngineBaseTest extends OcrTestCase
             // Pass:
             ['https://upload.wikimedia.org/wikipedia/commons/a/a9/Example.jpg', false],
             ['https://upload.wikimedia.org/wikipedia/commons/file.jpg', false],
+            ['//upload.wikimedia.org/wikipedia/commons/file.jpg', false],
             // Fail:
             ['https://foo.example.com/wikipedia/commons/a/a9/Example.jpg', true],
             ['https://en.wikisource.org/file.mov', true],


### PR DESCRIPTION
Both http and https are already allowed, and the actual validation is done based on hostname so there shouldn't be any issue with making this regex more lenient.

Bug: T324740