### PR TITLE
Return URL regex to requiring http prefix

### DIFF
--- a/src/Engine/EngineBase.php
+++ b/src/Engine/EngineBase.php
@@ -175,7 +175,7 @@ abstract class EngineBase
     {
         $hostRegex = implode('|', array_map('preg_quote', $this->getImageHosts()));
         $formatRegex = implode('|', self::ALLOWED_FORMATS);
-        $regex = "/(https?:)?\/\/($hostRegex)\/.+($formatRegex)$/";
+        $regex = "/^https?:\/\/($hostRegex)\/.+($formatRegex)$/";
         $matches = preg_match($regex, strtolower($imageUrl));
         if (1 !== $matches) {
             $params = [count($this->getImageHosts()), $this->intuition->listToText($this->getImageHosts())];

--- a/tests/Engine/EngineBaseTest.php
+++ b/tests/Engine/EngineBaseTest.php
@@ -66,7 +66,6 @@ class EngineBaseTest extends OcrTestCase
             // Pass:
             ['https://upload.wikimedia.org/wikipedia/commons/a/a9/Example.jpg', false],
             ['https://upload.wikimedia.org/wikipedia/commons/file.jpg', false],
-            ['//upload.wikimedia.org/wikipedia/commons/file.jpg', false],
             // Fail:
             ['https://foo.example.com/wikipedia/commons/a/a9/Example.jpg', true],
             ['https://en.wikisource.org/file.mov', true],


### PR DESCRIPTION
This partially undoes the change in 78e773cb1c308a2b9ed01370ba01ad79f4363f97 and makes the http/https prefix required for image URLs. This is because protocol-relative URLs are now being changed to https in OcrController, so by the time the URL gets to the EngineBase it's no longer relative.

Bug: T324740