### PR TITLE
Remove libopenjp2-7 installation from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,6 @@ jobs:
       # Note: libopenjp2-7 is already installed, but it's apparently corrupted
       run: |
         sudo apt-get update
-        sudo apt-get install -y --reinstall libopenjp2-7
         sudo apt-get install -y tesseract-ocr-all
 
     - name: Install wikimedia-ocr

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,6 @@ jobs:
         extensions: ast
 
     - name: Install tesseract
-      # Note: libopenjp2-7 is already installed, but it's apparently corrupted
       run: |
         sudo apt-get update
         sudo apt-get install -y tesseract-ocr-all


### PR DESCRIPTION
Change the github workflow file to not install the `libopenjp2-7` package during CI check