### PR TITLE
Remove toolinfo.json

### DIFF
--- a/toolinfo.json
+++ b/toolinfo.json
@@ -1,9 +1,0 @@
-{
-    "name": "ws-google-ocr",
-    "title": "Wikisource Google OCR",
-    "description": "An interface to the Google Vision API for Optical Character Recognition of scanned books on Wikisources.",
-    "url": "https://tools.wmflabs.org/ws-google-ocr",
-    "keywords": "wikisource, ocr, google, proofreading, transcription",
-    "author": "Sam Wilson",
-    "repository": "https://phabricator.wikimedia.org/source/tool-ws-google-ocr.git"
-}


### PR DESCRIPTION
Remove the `toolinfo.json` file that had old metadata about the tool and was no longer being used