### PR TITLE
Disable submit button during form submit

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -112,9 +112,9 @@ $(function () {
         });
     }
 
-    // Disable submit button during form submit
+    // Disable submit buttons during form submit
     $('form').on('submit', e => {
-        $('.submit-btn .btn').attr("disabled", true);
+        $('.submit-btn .btn, .submit-crop').attr("disabled", true);
     });
 
     var $ocrOutputDiv = $('.ocr-output');

--- a/assets/app.js
+++ b/assets/app.js
@@ -113,9 +113,14 @@ $(function () {
     }
 
     // Disable submit buttons during form submit
+    var submitBtns = $('.submit-btn .btn, .submit-crop')
     $('form').on('submit', e => {
-        $('.submit-btn .btn, .submit-crop').attr("disabled", true);
+        submitBtns.attr("disabled", true);
     });
+    // Re-enable submit buttons on pagehide, so that they are re-enabled if returned to via browser history
+    $(window).on('pagehide', e => {
+        submitBtns.attr("disabled", false);
+    })
 
     var $ocrOutputDiv = $('.ocr-output');
     if ($ocrOutputDiv.length) {

--- a/assets/app.js
+++ b/assets/app.js
@@ -112,6 +112,11 @@ $(function () {
         });
     }
 
+    // Disable submit button during form submit
+    $('form').on('submit', e => {
+        $('.submit-btn .btn').attr("disabled", true);
+    });
+
     var $ocrOutputDiv = $('.ocr-output');
     if ($ocrOutputDiv.length) {
         // Cropper.


### PR DESCRIPTION
A proposed fix for [Phabricator bug T334161 (Disable "Transcribe Full Page" button during transcription)](https://phabricator.wikimedia.org/T334161) which disables the button when the `onsubmit` event is fired. See the bug report itself for more info.