### PR TITLE
Add OCR models Fraktur and Latin for Tesseract

### DIFF
--- a/public/langs.json
+++ b/public/langs.json
@@ -1,4 +1,10 @@
 {
+    "Fraktur": {
+        "tesseract": "Fraktur"
+    },
+    "Latin": {
+        "tesseract": "Latin"
+    },
     "af": {
         "tesseract": "afr",
         "google": "af"

--- a/src/Engine/EngineBase.php
+++ b/src/Engine/EngineBase.php
@@ -36,6 +36,8 @@ abstract class EngineBase {
 
 	/** @var string[] Additional localized names for non-standard language codes. */
 	public const LANG_NAMES = [
+		'Fraktur' => 'Fraktur script',
+		'Latin' => 'Latin script',
 		'az-cyrl' => 'Azərbaycan (qədim yazı)',
 		'bali' => 'Balinese palm-leaf manuscripts 16th century',
 		'ben-print' => 'Bengali Printed Books +150 New',


### PR DESCRIPTION
Both are not language specific, but support historic and current scripts used by many European languages.