### PR TITLE
Update Swedish model for Transkribus

### DIFF
--- a/public/langs.json
+++ b/public/langs.json
@@ -504,9 +504,9 @@
         "tesseract": "swa",
         "google": "sw"
     },
-    "swe-2.1": {
+    "swe-3": {
         "transkribus": {
-            "htr": 45736
+            "htr": 53149
         }
     },
     "syr": {

--- a/src/Engine/EngineBase.php
+++ b/src/Engine/EngineBase.php
@@ -69,7 +69,7 @@ abstract class EngineBase {
 		'ru-petr1708' => 'Русский (старая орфография)',
 		'san' => 'Devanagari Mixed M1A',
 		'sr-latn' => 'Српски (латиница)',
-		'swe-2.1' => 'Stockholm Notaries 1700 2.1',
+		'swe-3' => 'Stockholm Notaries 1700 3.0',
 		'syr' => 'leššānā Suryāyā',
 		'uz-cyrl' => 'oʻzbekcha',
 		'yi-hd' => 'The Dybbuk for Yiddish Handwriting'


### PR DESCRIPTION
Updated the model ID and name of Swedish model
used by Transkribus engine

Bug: [T344349](https://phabricator.wikimedia.org/T344349)