### PR TITLE
Bump loader-utils and resolve-url-loader

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1845,9 +1845,9 @@
                     }
                 },
                 "loader-utils": {
-                    "version": "1.4.0",
-                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-                    "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+                    "version": "1.4.2",
+                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
+                    "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
                     "dev": true,
                     "requires": {
                         "big.js": "^5.2.2",
@@ -5796,9 +5796,9 @@
             "dev": true
         },
         "loader-utils": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
-            "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+            "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
             "dev": true,
             "requires": {
                 "big.js": "^5.2.2",
@@ -9516,9 +9516,9 @@
             "dev": true
         },
         "resolve-url-loader": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-3.1.2.tgz",
-            "integrity": "sha512-QEb4A76c8Mi7I3xNKXlRKQSlLBwjUV/ULFMP+G7n3/7tJZ8MG5wsZ3ucxP1Jz8Vevn6fnJsxDx9cIls+utGzPQ==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-3.1.5.tgz",
+            "integrity": "sha512-mgFMCmrV/tA4738EsFmPFE5/MaqSgUMe8LK971kVEKA/RrNVb7+VqFsg/qmKyythf34eyq476qIobP/gfFBGSQ==",
             "dev": true,
             "requires": {
                 "adjust-sourcemap-loader": "3.0.0",
@@ -9526,8 +9526,8 @@
                 "compose-function": "3.0.3",
                 "convert-source-map": "1.7.0",
                 "es6-iterator": "2.0.3",
-                "loader-utils": "1.2.3",
-                "postcss": "7.0.21",
+                "loader-utils": "^1.2.3",
+                "postcss": "7.0.36",
                 "rework": "1.0.1",
                 "rework-visit": "1.0.0",
                 "source-map": "0.6.1"
@@ -9561,36 +9561,30 @@
                         }
                     }
                 },
-                "emojis-list": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-                    "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
-                    "dev": true
-                },
                 "json5": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-                    "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+                    "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
                     "dev": true,
                     "requires": {
                         "minimist": "^1.2.0"
                     }
                 },
                 "loader-utils": {
-                    "version": "1.2.3",
-                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
-                    "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
+                    "version": "1.4.2",
+                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
+                    "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
                     "dev": true,
                     "requires": {
                         "big.js": "^5.2.2",
-                        "emojis-list": "^2.0.0",
+                        "emojis-list": "^3.0.0",
                         "json5": "^1.0.1"
                     }
                 },
                 "postcss": {
-                    "version": "7.0.21",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-                    "integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
+                    "version": "7.0.36",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+                    "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
                     "dev": true,
                     "requires": {
                         "chalk": "^2.4.2",


### PR DESCRIPTION
Bumps [loader-utils](https://github.com/webpack/loader-utils) and [resolve-url-loader](https://github.com/bholloway/resolve-url-loader/tree/HEAD/packages/resolve-url-loader). These dependencies needed to be updated together.

Updates `loader-utils` from 1.4.0 to 2.0.4
- [Release notes](https://github.com/webpack/loader-utils/releases)
- [Changelog](https://github.com/webpack/loader-utils/blob/v2.0.4/CHANGELOG.md)
- [Commits](https://github.com/webpack/loader-utils/compare/v1.4.0...v2.0.4)

Updates `loader-utils` from 2.0.0 to 2.0.4
- [Release notes](https://github.com/webpack/loader-utils/releases)
- [Changelog](https://github.com/webpack/loader-utils/blob/v2.0.4/CHANGELOG.md)
- [Commits](https://github.com/webpack/loader-utils/compare/v1.4.0...v2.0.4)

Updates `resolve-url-loader` from 3.1.2 to 3.1.5
- [Release notes](https://github.com/bholloway/resolve-url-loader/releases)
- [Changelog](https://github.com/bholloway/resolve-url-loader/blob/v5/packages/resolve-url-loader/CHANGELOG.md)
- [Commits](https://github.com/bholloway/resolve-url-loader/commits/3.1.5/packages/resolve-url-loader)

---
updated-dependencies:
- dependency-name: loader-utils dependency-type: indirect
- dependency-name: loader-utils dependency-type: indirect
- dependency-name: resolve-url-loader dependency-type: indirect ...