### PR TITLE
Fix crop URL parameter sanitization

### DIFF
--- a/src/Controller/OcrController.php
+++ b/src/Controller/OcrController.php
@@ -113,7 +113,10 @@ class OcrController extends AbstractController {
 		static::$params['langs'] = $this->getLangs( $this->request );
 		static::$params['image_hosts'] = $this->engine->getImageHosts();
 		$crop = $this->request->query->get( 'crop' );
-		if ( !is_array( $crop ) ) {
+		if ( !is_array( $crop )
+			|| isset( $crop['width'] ) && !$crop['width']
+			|| isset( $crop['height'] ) && !$crop['height']
+		) {
 			$crop = [];
 		}
 		static::$params['crop'] = array_map( 'intval', $crop );


### PR DESCRIPTION
Crop width and height can be empty strings, which were being turned into 0.