### PR TITLE
Set phpunit version to specific release to avoid issue

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,7 +14,7 @@
         <server name="APP_ENV" value="test" force="true" />
         <server name="SHELL_VERBOSITY" value="-1" />
         <server name="SYMFONY_PHPUNIT_REMOVE" value="" />
-        <server name="SYMFONY_PHPUNIT_VERSION" value="8.5" />
+        <server name="SYMFONY_PHPUNIT_VERSION" value="8.5.34" />
         <server name="KERNEL_CLASS" value="App\Kernel" />
 
         <!-- ###+ symfony/mailer ### -->


### PR DESCRIPTION
Newer versions of phpunit ship with composer.lock and so fail when `composer install` is run. This sets our phpunit version to the same one we were using before now, 8.5.34 (which of course could probably be updated to something newer but for now this will get tests passing again).