### PR TITLE
Add API endpoint to retrieve psm options

### DIFF
--- a/config/packages/nelmio_api_doc.yaml
+++ b/config/packages/nelmio_api_doc.yaml
@@ -8,4 +8,5 @@ nelmio_api_doc:
         path_patterns:
             - ^/api$
             - ^/api/available_langs$
+            - ^/api/tesseract/available_psms$
             - ^/api/transkribus/available_line_ids$

--- a/src/Controller/OcrController.php
+++ b/src/Controller/OcrController.php
@@ -312,6 +312,28 @@ class OcrController extends AbstractController {
 	}
 
 	/**
+	 * Get a list of Psms available for use with Tesseract.
+	 *
+	 * @Route("/api/tesseract/available_psms", name="apiPsms", methods={"GET"})
+	 * @OA\Response(response=200, description="List of available psm values and labels, in JSON format.")
+	 * @return JsonResponse
+	 */
+	public function apiAvailablePsms(): JsonResponse {
+		$this->setup();
+		$psms = [];
+		for ( $i = 0; $i <= 13; $i++ ) {
+			array_push( $psms, [
+				"value" => $i,
+				"label" => $this->intuition->msg( 'tesseract-psm-' . $i )
+			] );
+		}
+
+		return $this->getApiResponse( [
+			'available_psms' => $psms,
+		] );
+	}
+
+	/**
 	 * Get a list of available line detection IDs.
 	 *
 	 * @Route("/api/transkribus/available_line_ids", name="apiLineIds", methods={"GET"})


### PR DESCRIPTION
Added an end point for fetching psm options for Tesseract

Bug: [T353824](http://phabricator.wikimedia.org/T353824)