### PR TITLE
Move Tesseract PSM list to a single place

### DIFF
--- a/src/Controller/OcrController.php
+++ b/src/Controller/OcrController.php
@@ -190,6 +190,11 @@ class OcrController extends AbstractController {
 			sort( static::$params['available_line_id_langs'] );
 		}
 
+		// Get Tesseract's full list of PSMs.
+		/** @var TesseractEngine */
+		$tesseract = $this->engineFactory->get( 'tesseract' );
+		static::$params['available_psms'] = $tesseract->getAvailablePsms();
+
 		// Intution::listToText() isn't available via Twig, and we only want to do this for the view and not the API.
 		static::$params['image_hosts'] = $this->intuition->listToText( static::$params['image_hosts'] );
 
@@ -312,24 +317,18 @@ class OcrController extends AbstractController {
 	}
 
 	/**
-	 * Get a list of Psms available for use with Tesseract.
+	 * Get a list of PSMs available for use with Tesseract.
 	 *
 	 * @Route("/api/tesseract/available_psms", name="apiPsms", methods={"GET"})
-	 * @OA\Response(response=200, description="List of available psm values and labels, in JSON format.")
+	 * @OA\Response(response=200, description="List of available Tesseract PSM values and labels, in JSON format.")
 	 * @return JsonResponse
 	 */
 	public function apiAvailablePsms(): JsonResponse {
 		$this->setup();
-		$psms = [];
-		for ( $i = 0; $i <= 13; $i++ ) {
-			array_push( $psms, [
-				"value" => $i,
-				"label" => $this->intuition->msg( 'tesseract-psm-' . $i )
-			] );
-		}
-
+		/** @var TesseractEngine */
+		$tesseract = $this->engineFactory->get( 'tesseract' );
 		return $this->getApiResponse( [
-			'available_psms' => $psms,
+			'available_psms' => $tesseract->getAvailablePsms(),
 		] );
 	}
 

--- a/src/Engine/EngineFactory.php
+++ b/src/Engine/EngineFactory.php
@@ -7,7 +7,7 @@ use App\Exception\EngineNotFoundException;
 
 class EngineFactory {
 
-	/** @var array<string, EngineBase> */
+	/** @var array<string, TesseractEngine|GoogleCloudVisionEngine|TranskribusEngine> */
 	private $engines;
 
 	/**
@@ -29,7 +29,7 @@ class EngineFactory {
 
 	/**
 	 * @param string $name
-	 * @return EngineBase
+	 * @return TesseractEngine|GoogleCloudVisionEngine|TranskribusEngine
 	 */
 	public function get( string $name ): EngineBase {
 		if ( !isset( $this->engines[$name] ) ) {

--- a/src/Engine/TesseractEngine.php
+++ b/src/Engine/TesseractEngine.php
@@ -85,6 +85,26 @@ class TesseractEngine extends EngineBase {
 	}
 
 	/**
+	 * Get available PSM IDs and values.
+	 * @return mixed[][]
+	 */
+	public function getAvailablePsms(): array {
+		$psms = [];
+		$psmIds = [ 0, 1, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 ];
+		foreach ( $psmIds as $psmId ) {
+			array_push( $psms, [
+				'value' => $psmId,
+				// The following messages can be used here: 'tesseract-psm-0', 'tesseract-psm-1',
+				// 'tesseract-psm-3', 'tesseract-psm-4', 'tesseract-psm-5', 'tesseract-psm-6', 'tesseract-psm-7',
+				// 'tesseract-psm-8', 'tesseract-psm-9', 'tesseract-psm-10', 'tesseract-psm-11', 'tesseract-psm-12',
+				// 'tesseract-psm-13'
+				'label' => $this->intuition->msg( 'tesseract-psm-' . $psmId ),
+			] );
+		}
+		return $psms;
+	}
+
+	/**
 	 * Validates the given option.
 	 * @param string $option
 	 * @param int $given

--- a/templates/_tesseract_options.html.twig
+++ b/templates/_tesseract_options.html.twig
@@ -3,12 +3,8 @@
     <div class="form-group">
         <label for="psm">{{ msg('tesseract-psm-label') }}</label>
         <select name="psm" id="psm" class="form-control">
-            {# The following messages are used:
-             #   'tesseract-psm-0', 'tesseract-psm-1', 'tesseract-psm-2', 'tesseract-psm-3', 'tesseract-psm-4',
-             #   'tesseract-psm-5', 'tesseract-psm-6', 'tesseract-psm-7', 'tesseract-psm-8', 'tesseract-psm-9',
-             #   'tesseract-psm-10', 'tesseract-psm-11', 'tesseract-psm-12', 'tesseract-psm-13' #}
-            {% for i in 0..13 %}
-                <option value="{{ i }}" {% if i == psm %}selected="selected"{% endif %}>{{ msg('tesseract-psm-' ~ i) }}</option>
+            {% for psm_info in available_psms %}
+                <option value="{{ psm_info.value }}" {% if psm_info.value == psm %}selected="selected"{% endif %}>{{ psm_info.label }}</option>
             {% endfor %}
         </select>
         <p class="help-block">


### PR DESCRIPTION
Rather than iterating through 0..13 in two different places, add a new method to the TesseractEngine to return the canonical list. This means we can exclude number 2 which is not implemented.

Bug: T353824