### PR TITLE
Add Madurese to Google models.json config

### DIFF
--- a/public/models.json
+++ b/public/models.json
@@ -240,6 +240,10 @@
             "languages": ["lv"],
             "title": "latviešu"
         },
+        "mad": {
+            "languages": ["mad"],
+            "title": "Madhura, Basa Mathura, بَهاسَ مَدورا Madurese"
+        },
         "mi": {
             "languages": ["mi"],
             "title": "Māori"


### PR DESCRIPTION
Set the model title to be what's listed in the Google API docs, for better autocomplete.

Bug: T381459