### PR TITLE
Remove EngineBase::getLangCodes() as not required

### DIFF
--- a/src/Engine/EngineBase.php
+++ b/src/Engine/EngineBase.php
@@ -116,18 +116,6 @@ abstract class EngineBase {
 	}
 
 	/**
-	 * Transform the given ISO 639-1 codes into the language codes needed by this type of Engine.
-	 * @param string[] $langs
-	 * @return mixed[]
-	 */
-	public function getLangCodes( array $langs ): array {
-		return array_map( function ( $lang ) {
-			$language = $this->getModelList()[ $lang ];
-			return isset( $language ) ? $lang : '';
-		}, $langs );
-	}
-
-	/**
 	 * Set the allowed image hosts.
 	 * @param string $imageHosts
 	 */

--- a/src/Engine/GoogleCloudVisionEngine.php
+++ b/src/Engine/GoogleCloudVisionEngine.php
@@ -59,7 +59,7 @@ class GoogleCloudVisionEngine extends EngineBase {
 
 		$imageContext = new ImageContext();
 		if ( $validLangs ) {
-			$imageContext->setLanguageHints( $this->getLangCodes( $validLangs ) );
+			$imageContext->setLanguageHints( $validLangs );
 		}
 
 		if ( !$this->imageAnnotator ) {

--- a/src/Engine/TesseractEngine.php
+++ b/src/Engine/TesseractEngine.php
@@ -62,7 +62,7 @@ class TesseractEngine extends EngineBase {
 		$this->ocr->imageData( $image->getData(), $image->getSize() );
 
 		if ( $validLangs ) {
-			$this->ocr->lang( ...$this->getLangCodes( $validLangs ) );
+			$this->ocr->lang( ...$validLangs );
 		}
 
 		// Env vars are passed through by the thiagoalessio/tesseract_ocr package to the tesseract command,

--- a/src/Engine/TranskribusEngine.php
+++ b/src/Engine/TranskribusEngine.php
@@ -136,12 +136,13 @@ class TranskribusEngine extends EngineBase {
 		if ( !$validLangs ) {
 			throw new OcrException( 'transkribus-no-lang-error' );
 		}
-		$langCodes = $this->getLangCodes( $validLangs );
-		if ( count( $langCodes ) > 1 ) {
+
+		if ( count( $validLangs ) > 1 ) {
 			throw new OcrException( 'transkribus-multiple-lang-error' );
 		}
-		$htrModelId = (int)$langCodes[0]['htr'];
-
+		$modelCode = $validLangs[0];
+		$modelInfo = $this->getModelList()[$modelCode];
+		$htrModelId = (int)$modelInfo['htr'];
 		$processId = $this->transkribusClient->initProcess( $imageUrl, $htrModelId, $this->lineId, $points );
 
 		$resText = '';

--- a/tests/Engine/EngineBaseTest.php
+++ b/tests/Engine/EngineBaseTest.php
@@ -128,14 +128,6 @@ class EngineBaseTest extends OcrTestCase {
 	}
 
 	/**
-	 * @covers EngineBase::getLangCodes
-	 */
-	public function testLangCodes(): void {
-		static::assertSame( [ 'eng', 'fra' ], $this->tesseractEngine->getLangCodes( [ 'eng', 'fra' ] ) );
-		static::assertSame( [ 'en', 'iw' ], $this->googleEngine->getLangCodes( [ 'en', 'iw' ] ) );
-	}
-
-	/**
 	 * @covers EngineBase::getModelName
 	 * @covers EngineBase::getValidModels
 	 */


### PR DESCRIPTION
Remove the above method as it was not checking for the existence correctly and anyway was only ever being passed valid model codes.

Also fix a bug in the TranskribusEngine with the HTR ID not being retrieved correctly.