### PR TITLE
Fix iteration over line-ID options values

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -58,7 +58,7 @@ function fetchLineModelsJSON () {
 function updateLineModelOptions () {
     const staticOptions = $lineDetectionSelect[0].options;
     let staticOptionData = []; 
-    staticOptions.forEach(option => {
+    Array.prototype.forEach.call(staticOptions, option => {
         staticOptionData.push({
             text: option.text,
             value: option.value


### PR DESCRIPTION
It's not possible to iterate on a HTMLOptionsCollection with forEach directly, it must be called indirectly.

Bug: T384789