### PR TITLE
Add Open Graph metadata for image and description

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,7 +1,7 @@
 {
     "@metadata": {},
     "title": "WikimediaOCR",
-    "subtitle": "Transcribe text from images",
+    "subtitle": "A tool to transcribe text from scanned images on Wikimedia Commons, for use on Wikisource and elsewhere.",
     "form-heading": "Transcribe an image",
     "image-url": "Image URL",
     "image-url-help": "Insert an image URL hosted on a Wikimedia server such as: $1",

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -3,6 +3,15 @@
     <head>
         <meta charset="UTF-8">
         <title>{% block title %}{{ msg('title') }}{% endblock %}</title>
+        <meta property="og:title" content="{{ msg('title') }}" />
+        <meta property="og:description" content="{{ msg('subtitle') }}"/>
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content="{{ url('home') }}"/>
+        <meta property="og:image" content="{{ absolute_url(asset('build/images/WikimediaOCR-logo.svg')) }}" />
+        <meta property="og:image:width" content="50" />
+        <meta property="og:image:height" content="50" />
+        <meta property="og:image:type" content="image/svg+xml" />
+        <meta property="og:image:alt" content="WikimediaOCR Logo" />
         <link rel="icon" href="{{ asset('favicon.ico') }}" />
         {% block stylesheets %}
             {{ encore_entry_link_tags('app') }}


### PR DESCRIPTION
Fixes [T349467](https://phabricator.wikimedia.org/T349467)

- Add title, description and image open_graph tags
- Update Description Text