### PR TITLE
T413556-Add rotate option to OCR tool

### DIFF
--- a/src/Controller/OcrController.php
+++ b/src/Controller/OcrController.php
@@ -63,6 +63,7 @@ class OcrController extends AbstractController {
 		'psm' => TesseractEngine::DEFAULT_PSM,
 		'crop' => [],
 		'line_id' => TranskribusEngine::DEFAULT_LINEID,
+		'rotate' => 0,
 	];
 
 	/**
@@ -120,6 +121,9 @@ class OcrController extends AbstractController {
 			$crop = [];
 		}
 		static::$params['crop'] = array_map( 'intval', $crop );
+		$rotate = (int)$this->request->query->get( 'rotate', 0 );
+		// Normalize rotation to 0-359 range
+		static::$params['rotate'] = ( ( $rotate % 360 ) + 360 ) % 360;
 	}
 
 	/**
@@ -271,6 +275,12 @@ class OcrController extends AbstractController {
 	 *     description="Crop parameter `height` value.",
 	 * @OA\Schema(type="int")
 	 * )
+	 * @OA\Parameter(
+	 *     name="rotate",
+	 *     in="query",
+	 *     description="Rotation angle in degrees (0-359).",
+	 * @OA\Schema(type="int")
+	 * )
 	 * @OA\Response(response=200, description="The OCR text, and other data.")
 	 * @return JsonResponse
 	 */
@@ -390,6 +400,7 @@ class OcrController extends AbstractController {
 				implode( '|', array_map( 'strval', static::$params['crop'] ) ),
 				static::$params['psm'],
 				static::$params['line_id'],
+				static::$params['rotate'],
 				// Warning messages are localized
 				$this->intuition->getLang(),
 			]
@@ -401,7 +412,8 @@ class OcrController extends AbstractController {
 				static::$params['image'],
 				$invalidLangsMode,
 				static::$params['crop'],
-				static::$params['langs']
+				static::$params['langs'],
+				static::$params['rotate']
 			);
 		} );
 		if ( !$result instanceof EngineResult ) {

--- a/src/Engine/GoogleCloudVisionEngine.php
+++ b/src/Engine/GoogleCloudVisionEngine.php
@@ -51,7 +51,8 @@ class GoogleCloudVisionEngine extends EngineBase {
 		string $imageUrl,
 		string $invalidLangsMode,
 		array $crop,
-		?array $langs = null
+		?array $langs = null,
+		int $rotate = 0
 	): EngineResult {
 		$this->checkImageUrl( $imageUrl );
 
@@ -66,7 +67,7 @@ class GoogleCloudVisionEngine extends EngineBase {
 			throw new OcrException( 'google-error', [ 'Key for Google OCR engine is missing' ] );
 		}
 
-		$image = $this->getImage( $imageUrl, $crop );
+		$image = $this->getImage( $imageUrl, $crop, false, $rotate );
 		$imageUrlOrData = $image->hasData() ? $image->getData() : $image->getUrl();
 		$response = $this->imageAnnotator->textDetection( $imageUrlOrData, [ 'imageContext' => $imageContext ] );
 
@@ -77,7 +78,7 @@ class GoogleCloudVisionEngine extends EngineBase {
 		if ( $response->getError()
 			&& stripos( $response->getError()->getMessage(), 'download the content and pass it in' ) !== false
 		) {
-			$image = $this->getImage( $imageUrl, $crop, self::DO_DOWNLOAD_IMAGE );
+			$image = $this->getImage( $imageUrl, $crop, self::DO_DOWNLOAD_IMAGE, $rotate );
 			$response = $this->imageAnnotator->textDetection( $image->getData(), [ 'imageContext' => $imageContext ] );
 		}
 

--- a/src/Engine/Image.php
+++ b/src/Engine/Image.php
@@ -16,6 +16,9 @@ class Image {
 	/** @var int[] Array of floats with keys: `x`, `y`, `width`, and `height`. */
 	private $crop;
 
+	/** @var int Rotation angle in degrees. */
+	private $rotate;
+
 	/** @var string|null Image data. */
 	private $data;
 
@@ -25,10 +28,12 @@ class Image {
 	/**
 	 * @param string $imageUrl
 	 * @param int[] $crop
+	 * @param int $rotate
 	 */
-	public function __construct( string $imageUrl, array $crop = [] ) {
+	public function __construct( string $imageUrl, array $crop = [], int $rotate = 0 ) {
 		$this->imageUrl = $imageUrl;
 		$this->crop = $crop;
+		$this->rotate = $rotate;
 	}
 
 	/**
@@ -51,6 +56,22 @@ class Image {
 			new Point( $this->crop['x'], $this->crop['y'] ),
 			new Box( $this->crop['width'], $this->crop['height'] )
 		);
+	}
+
+	/**
+	 * Check if rotation is needed.
+	 * @return bool
+	 */
+	public function needsRotation(): bool {
+		return $this->rotate !== 0;
+	}
+
+	/**
+	 * Get the rotation angle in degrees.
+	 * @return int
+	 */
+	public function getRotate(): int {
+		return $this->rotate;
 	}
 
 	public function hasData(): bool {

--- a/src/Engine/TesseractEngine.php
+++ b/src/Engine/TesseractEngine.php
@@ -51,14 +51,15 @@ class TesseractEngine extends EngineBase {
 		string $imageUrl,
 		string $invalidLangsMode,
 		array $crop,
-		?array $langs = null
+		?array $langs = null,
+		int $rotate = 0
 	): EngineResult {
 		// Check the URL and fetch the image data.
 		$this->checkImageUrl( $imageUrl );
 
 		[ $validLangs, $invalidLangs ] = $this->filterValidLangs( $langs, $invalidLangsMode );
 
-		$image = $this->getImage( $imageUrl, $crop, self::DO_DOWNLOAD_IMAGE );
+		$image = $this->getImage( $imageUrl, $crop, self::DO_DOWNLOAD_IMAGE, $rotate );
 		$this->ocr->imageData( $image->getData(), $image->getSize() );
 
 		if ( $validLangs ) {

--- a/src/Engine/TranskribusEngine.php
+++ b/src/Engine/TranskribusEngine.php
@@ -114,7 +114,8 @@ class TranskribusEngine extends EngineBase {
 		string $imageUrl,
 		string $invalidLangsMode,
 		array $crop,
-		?array $langs = null
+		?array $langs = null,
+		int $rotate = 0
 	): EngineResult {
 		$this->checkImageUrl( $imageUrl );
 
@@ -140,7 +141,7 @@ class TranskribusEngine extends EngineBase {
 		$modelCode = $validLangs[0];
 		$modelInfo = $this->getModelList()[$modelCode];
 		$htrModelId = (int)$modelInfo['htr'];
-		$image = $this->getImage( $imageUrl, $crop, self::DO_DOWNLOAD_IMAGE );
+		$image = $this->getImage( $imageUrl, $crop, self::DO_DOWNLOAD_IMAGE, $rotate );
 		$processId = $this->transkribusClient->initProcess( $image, $htrModelId, $this->lineId, $points );
 
 		$resText = '';

--- a/templates/output.html.twig
+++ b/templates/output.html.twig
@@ -93,12 +93,22 @@
                                 </button>
                             </div>
 
+                            <div class="btn-group" role="group">
+                                <button type="button" class="btn btn-default rotate-left" title="Rotate left">
+                                    ↺
+                                </button>
+                                <button type="button" class="btn btn-default rotate-right" title="Rotate right">
+                                    ↻
+                                </button>
+                            </div>
+
                             <input type="submit" value="{{ msg( 'submit-crop' ) }}" class="submit-crop btn btn-info disabled" disabled />
 
                             <input type="hidden" name="crop[x]" value="{% if crop.x is defined %}{{ crop.x }}{% endif %}" />
                             <input type="hidden" name="crop[y]" value="{% if crop.y is defined %}{{ crop.y }}{% endif %}" />
                             <input type="hidden" name="crop[width]" value="{% if crop.width is defined %}{{ crop.width }}{% endif %}" />
                             <input type="hidden" name="crop[height]" value="{% if crop.height is defined %}{{ crop.height }}{% endif %}" />
+                            <input type="hidden" name="rotate" id="rotate" value="{% if rotate is defined %}{{ rotate }}{% else %}0{% endif %}" />
                         </div>
                         <div><!-- This div is required for Cropper.js -->
                             <img id="source-image" class="img-responsive" src="{{ app.request.get('image') }}" alt="{{ msg('img-alt-text') }}" />


### PR DESCRIPTION
Add rotate option to OCR tool
- Apply image rotation server-side (Imagine) before cropping and OCR,
  - thread the rotate parameter through the controller and engine layers, and add simple UI controls (output.html.twig, assets/app.js) to rotate via Cropper.js.
- Also include rotate in the cache key so rotated results are cached separately.

Fixes: [T413556](https://phabricator.wikimedia.org/T413556)

I noticed there’s already a PR open (#147) addressing this issue. Since that patch includes some changes that might not be strictly necessary, and it hasn’t had recent updates, I went ahead and explored my own implementation in the meantime.