### PR TITLE
Add lang-switching dropdown to site footer

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -30,6 +30,8 @@
     "api-tooltip": "View the API documentation",
     "version": "Version $1",
     "report-issue": "Report an issue",
+    "language": "Language:",
+    "language-switch": "Switch language",
     "langs-placeholder": "Leave blank for automatic language detection.",
     "langs-param-error": "The following {{PLURAL:$1|language is|languages are}} not supported by the OCR engine: $2",
     "loading-message": "Performing transcription...",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -37,6 +37,8 @@
 	"api-tooltip": "Tooltip for the API link in the footer.",
 	"version": "Link text in the footer for the source code link.\n\nParameter:\n* $1 – the current application version number.\n\n{{identical|Version}}",
 	"report-issue": "Link text in the footer for the issue-reporting link.",
+	"language": "Label for the language-switching dropdown.",
+	"language-switch": "Button text for the language-switching dropdown.",
 	"langs-placeholder": "Placeholder text for the language input field.",
 	"langs-param-error": "Error message displayed when invalid language(s) are submitted.\n\nParameters:\n* $1 – number of invalid languages\n* $2 - the list of invalid languages\n\nOCR is a common abbreviation in English for \"Optical Characters Recognition\".",
 	"loading-message": "Loading message displayed when the transcription is being performed",

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -55,21 +55,40 @@
 
             <hr/>
             <footer>
-                <a target="_blank" href="https://github.com/wikimedia/wikimedia-ocr/releases/tag/{{ git_tag() }}">
-                    {{ msg('version', [git_tag()]) -}}
-                </a>
-                &bull;
-                <a target="_blank" href="https://www.mediawiki.org/wiki/Help:Extension:Wikisource/Wikimedia_OCR">
-                    {{ msg('documentation') -}}
-                </a>
-                &bull;
-                <a href="{{ path('app.swagger_ui') }}" title="{{ msg('api-tooltip') }}">
-                    {{ msg('api') -}}
-                </a>
-                &bull;
-                <a target="_blank" href="https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?tags=wikimedia_ocr">
-                    {{ msg('report-issue') -}}
-                </a>
+                <p>
+                    <a target="_blank" href="https://github.com/wikimedia/wikimedia-ocr/releases/tag/{{ git_tag() }}">
+                        {{ msg('version', [git_tag()]) -}}
+                    </a>
+                    &bull;
+                    <a target="_blank" href="https://www.mediawiki.org/wiki/Help:Extension:Wikisource/Wikimedia_OCR">
+                        {{ msg('documentation') -}}
+                    </a>
+                    &bull;
+                    <a href="{{ path('app.swagger_ui') }}" title="{{ msg('api-tooltip') }}">
+                        {{ msg('api') -}}
+                    </a>
+                    &bull;
+                    <a target="_blank" href="https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?tags=wikimedia_ocr">
+                        {{ msg('report-issue') -}}
+                    </a>
+                </p>
+                <form action="{{path('home')}}" method="get" class="form-inline">
+                    <div class="form-group">
+                        <label for="uselang">{{ msg('language') }}</label>
+                        <select name="uselang" class="form-control" id="uselang">
+                            {% for code,lang in all_langs() %}
+                                <option value="{{code}}" {% if code == lang() %}selected{% endif %}>
+                                    {% if lang %}
+                                        {{lang}}
+                                    {% else %}
+                                        ({{code}})
+                                    {% endif %}
+                                </option>
+                            {% endfor %}
+                        </select>
+                        <input type="submit" value="{{msg('language-switch')}}" class="btn btn-default">
+                    </div>
+                </form>
             </footer>
         </main>
     </body>


### PR DESCRIPTION
Add a form to the site footer with which to change the current uselang setting, with a dropdown containing all available translation languages.

Bug: T416783