### PR TITLE
Fix form submit button handling to exclude the language selector

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -57,7 +57,7 @@ function fetchLineModelsJSON () {
  */
 function updateLineModelOptions () {
     const staticOptions = $lineDetectionSelect[0].options;
-    let staticOptionData = []; 
+    let staticOptionData = [];
     Array.prototype.forEach.call(staticOptions, option => {
         staticOptionData.push({
             text: option.text,
@@ -70,7 +70,7 @@ function updateLineModelOptions () {
 
     // append static options
     staticOptionData.slice(0, 2).forEach(staticOption => {
-        $lineDetectionSelect.append(new Option(staticOption.text, staticOption.value, staticOption.value === null, false));    
+        $lineDetectionSelect.append(new Option(staticOption.text, staticOption.value, staticOption.value === null, false));
     });
 
     // append all other line detection models as options
@@ -135,7 +135,7 @@ $(function () {
         }
     });
 
-    // modify selected engine after loading the page with preselected engine 
+    // modify selected engine after loading the page with preselected engine
     let $engineRadioFields = $('[name=engine]:checked');
     if($engineRadioFields.val() === 'transkribus') {
         $select2.attr('data-placeholder', '')
@@ -155,14 +155,14 @@ $(function () {
         });
     }
 
-    var submitBtns = $('.submit-btn .btn, .submit-crop')
-    $('form').on('submit', e => {
-        submitBtns.attr("disabled", true);
+    const $submitBtns = $('.submit-full, .submit-crop')
+    $submitBtns.closest('form').on('submit', e => {
+        $submitBtns.attr("disabled", true);
         $(".loader").removeClass('hidden');
     });
     // Re-enable submit buttons on pagehide, so that they are re-enabled if returned to via browser history
     $(window).on('pagehide', e => {
-        submitBtns.attr("disabled", false);
+        $submitBtns.attr("disabled", false);
         $(".loader").addClass('hidden');
     });
 
@@ -219,7 +219,7 @@ $(function () {
         });
 
         // When submitting the main 'transcribe' button, do not send crop dimensions.
-        $('.submit-btn .btn').on('click', e => {
+        $('.submit-full').on('click', e => {
             x.value = null;
             y.value = null;
             width.value = null;

--- a/templates/output.html.twig
+++ b/templates/output.html.twig
@@ -37,11 +37,11 @@
                 <label id="transkribus-lang-label" for="lang" class="lang-label {% if engine != 'transkribus' %}hidden{% endif %}">
                     {{ msg('transkribus-language-code') }}
                 </label>
-                <select 
-                    id="lang" 
-                    class="form-control" 
-                    name="langs[]" 
-                    multiple 
+                <select
+                    id="lang"
+                    class="form-control"
+                    name="langs[]"
+                    multiple
                     {% if engine == 'transkribus' %}
                         required
                     {% else %}
@@ -63,7 +63,7 @@
         {% include '_transkribus_options.html.twig' with {engine: engine} %}
 
         <div class="form-group submit-btn">
-            <input type="submit" value="{{ msg( 'submit' ) }}" class="btn btn-info" />
+            <input type="submit" value="{{ msg( 'submit' ) }}" class="submit-full btn btn-info" />
         </div>
 
         <div class="loader hidden">


### PR DESCRIPTION
The OCR submit buttons are disabled after clicking, but we don't need the same behaviour for the language switcher, and adding it there was also displaying the loading message for the other form.

Bug: T416783