### PR TITLE
T413556 - Add image rotation functionality with UI controls and localization

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -166,34 +166,78 @@ $(function () {
         $(".loader").addClass('hidden');
     });
 
+    // --- Image workspace (crop, rotate, OCR results) ---
     var $ocrOutputDiv = $('.ocr-output');
-    if ($ocrOutputDiv.length) {
-        // Cropper.
-        const img = document.getElementById('source-image'),
-            x = document.querySelector('[name="crop[x]"]'),
-            y = document.querySelector('[name="crop[y]"]'),
-            width  = document.querySelector('[name="crop[width]"]'),
-            height = document.querySelector('[name="crop[height]"]'),
-            $modeButtons = $('.drag-mode');
+    const img = document.getElementById('source-image');
+    const x = document.querySelector('[name="crop[x]"]');
+    const y = document.querySelector('[name="crop[y]"]');
+    const width = document.querySelector('[name="crop[width]"]');
+    const height = document.querySelector('[name="crop[height]"]');
+    const rotate = document.getElementById('rotate');
+    const $modeButtons = $('.drag-mode');
+    let cropperInstance = null;
+
+    /**
+     * Initialize (or re-initialize) Cropper.js on the source image.
+     */
+    function initCropper() {
+        if (cropperInstance) {
+            cropperInstance.destroy();
+            cropperInstance = null;
+        }
+
         new Cropper(img, {
             viewMode: 2,
             dragMode: 'move',
-            // Remove double-click drag mode toggling, because we've got buttons for that.
             toggleDragModeOnDblclick: false,
-            // Only show a crop area if it is defined.
             autoCrop: width.value > 0 && height.value > 0,
             responsive: true,
             ready () {
+                cropperInstance = this.cropper;
+
                 // Make textarea match height of image.
                 $('#text').css({
                     height: this.cropper.getContainerData().height,
                 });
                 // React to changes in the crop-mode buttons.
-                $modeButtons.on( 'click', event => {
+                $modeButtons.off('click.cropmode').on('click.cropmode', event => {
                     const $button = $(event.currentTarget);
                     $modeButtons.removeClass('active');
                     $button.addClass('active');
                     this.cropper.setDragMode($button.data('drag-mode'));
+                });
+                // Initialize rotation if present
+                if (rotate && rotate.value && rotate.value !== '0') {
+                    this.cropper.rotate(Number.parseFloat(rotate.value));
+                }
+
+                // Update rotation value from cropper
+                const updateRotationValue = () => {
+                    if (rotate && cropperInstance) {
+                        const currentRotate = cropperInstance.getData().rotate || 0;
+                        // Normalize to 0-359 range
+                        const normalizedRotate = ((currentRotate % 360) + 360) % 360;
+                        rotate.value = Math.round(normalizedRotate);
+                    }
+                };
+
+                // Rotation buttons
+                $('.rotate-left').off('click.rotate').on('click.rotate', function(e) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    if (cropperInstance && typeof cropperInstance.rotate === 'function') {
+                        cropperInstance.rotate(-90);
+                        updateRotationValue();
+                    }
+                });
+
+                $('.rotate-right').off('click.rotate').on('click.rotate', function(e) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    if (cropperInstance && typeof cropperInstance.rotate === 'function') {
+                        cropperInstance.rotate(90);
+                        updateRotationValue();
+                    }
                 });
             },
             data: {
@@ -207,23 +251,67 @@ $(function () {
                 y.value = Math.round(event.detail.y);
                 width.value = Math.round(event.detail.width);
                 height.value = Math.round(event.detail.height);
-                // Enable the cropping buttons. No need to disable them ever because there's no way to remove the crop box.
-                $('.btn.submit-crop').attr('disabled', false).removeClass('disabled');
-                $modeButtons.attr('disabled', false);
+                // Only enable the crop-submit button when a real crop area has been drawn by the user.
+                if (event.detail.width > 0 && event.detail.height > 0 && cropperInstance && cropperInstance.cropped) {
+                    $('.btn.submit-crop').attr('disabled', false).removeClass('disabled');
+                    $modeButtons.attr('disabled', false);
+                }
             }
         });
-
-        // When setting a new image URL, remove the preview and the crop dimensions.
-        $('[name=image]').on('change', e => {
-            $ocrOutputDiv.remove();
-        });
-
-        // When submitting the main 'transcribe' button, do not send crop dimensions.
-        $('.submit-full').on('click', e => {
-            x.value = null;
-            y.value = null;
-            width.value = null;
-            height.value = null;
-        });
     }
+
+    // Initialize cropper when image loads (works for both server-rendered and JS-set src).
+    $(img).on('load', function() {
+        $ocrOutputDiv.removeClass('hidden');
+        initCropper();
+    });
+
+    // If image is already loaded (cached), initialize immediately.
+    if (img.src && img.complete && img.naturalWidth > 0) {
+        initCropper();
+    }
+
+    // Hide output section on image load error (only when no OCR text present).
+    $(img).on('error', function() {
+        if (!$('#text').val()) {
+            $ocrOutputDiv.addClass('hidden');
+        }
+    });
+
+    // When the image URL input changes, update the source image.
+    $('[name=image]').on('input', function() {
+        const url = $(this).val();
+        if (url) {
+            // Reset crop and rotation for new image.
+            x.value = '';
+            y.value = '';
+            width.value = '';
+            height.value = '';
+            if (rotate) {
+                rotate.value = 0;
+            }
+            // Clear any existing OCR text.
+            $('#text').val('');
+            $('.copy-button').addClass('hidden');
+
+            // Destroy existing cropper before changing src.
+            if (cropperInstance) {
+                cropperInstance.destroy();
+                cropperInstance = null;
+            }
+            img.src = url;
+            // The 'load' event will show the output div and init cropper.
+        } else {
+            $ocrOutputDiv.addClass('hidden');
+        }
+    });
+
+    // When submitting the main 'transcribe' button, do not send crop dimensions.
+    // Rotation is preserved — the user intentionally set it.
+    $('.submit-full').on('click', e => {
+        x.value = null;
+        y.value = null;
+        width.value = null;
+        height.value = null;
+    });
 });

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -78,5 +78,7 @@
     "transkribus-job-description": "Description",
     "transkribus-job-start": "Started",
     "transkribus-job-end": "Finished",
-    "transkribus-job-waited": "Start delay (minutes)"
+    "transkribus-job-waited": "Start delay (minutes)",
+    "rotate-left": "Rotate left",
+    "rotate-right": "Rotate right"
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -85,5 +85,7 @@
 	"transkribus-job-description": "Table column header text for the job description.",
 	"transkribus-job-start": "Table column header text for the job-started date.",
 	"transkribus-job-end": "Table column header text for the job-ended date",
-	"transkribus-job-waited": "Table column header text for the job start-delay, in minutes."
+	"transkribus-job-waited": "Table column header text for the job start-delay, in minutes.",
+	"rotate-left": "Tooltip for the rotate-left button.",
+	"rotate-right": "Tooltip for the rotate-right button."
 }

--- a/src/Controller/OcrController.php
+++ b/src/Controller/OcrController.php
@@ -63,6 +63,7 @@ class OcrController extends AbstractController {
 		'psm' => TesseractEngine::DEFAULT_PSM,
 		'crop' => [],
 		'line_id' => TranskribusEngine::DEFAULT_LINEID,
+		'rotate' => 0,
 	];
 
 	/**
@@ -120,6 +121,9 @@ class OcrController extends AbstractController {
 			$crop = [];
 		}
 		static::$params['crop'] = array_map( 'intval', $crop );
+		$rotate = (int)$this->request->query->get( 'rotate', 0 );
+		// Normalize rotation to 0-359 range
+		static::$params['rotate'] = ( ( $rotate % 360 ) + 360 ) % 360;
 	}
 
 	/**
@@ -271,6 +275,12 @@ class OcrController extends AbstractController {
 	 *     description="Crop parameter `height` value.",
 	 * @OA\Schema(type="int")
 	 * )
+	 * @OA\Parameter(
+	 *     name="rotate",
+	 *     in="query",
+	 *     description="Rotation angle in degrees (0-359).",
+	 * @OA\Schema(type="int")
+	 * )
 	 * @OA\Response(response=200, description="The OCR text, and other data.")
 	 * @return JsonResponse
 	 */
@@ -390,6 +400,7 @@ class OcrController extends AbstractController {
 				implode( '|', array_map( 'strval', static::$params['crop'] ) ),
 				static::$params['psm'],
 				static::$params['line_id'],
+				static::$params['rotate'],
 				// Warning messages are localized
 				$this->intuition->getLang(),
 			]
@@ -401,7 +412,8 @@ class OcrController extends AbstractController {
 				static::$params['image'],
 				$invalidLangsMode,
 				static::$params['crop'],
-				static::$params['langs']
+				static::$params['langs'],
+				static::$params['rotate']
 			);
 		} );
 		if ( !$result instanceof EngineResult ) {

--- a/src/Engine/GoogleCloudVisionEngine.php
+++ b/src/Engine/GoogleCloudVisionEngine.php
@@ -51,7 +51,8 @@ class GoogleCloudVisionEngine extends EngineBase {
 		string $imageUrl,
 		string $invalidLangsMode,
 		array $crop,
-		?array $langs = null
+		?array $langs = null,
+		int $rotate = 0
 	): EngineResult {
 		$this->checkImageUrl( $imageUrl );
 
@@ -66,7 +67,7 @@ class GoogleCloudVisionEngine extends EngineBase {
 			throw new OcrException( 'google-error', [ 'Key for Google OCR engine is missing' ] );
 		}
 
-		$image = $this->getImage( $imageUrl, $crop );
+		$image = $this->getImage( $imageUrl, $crop, false, $rotate );
 		$imageUrlOrData = $image->hasData() ? $image->getData() : $image->getUrl();
 		$response = $this->imageAnnotator->documentTextDetection(
 			$imageUrlOrData,
@@ -81,11 +82,8 @@ class GoogleCloudVisionEngine extends EngineBase {
 			$response->getError()
 			&& stripos( $response->getError()->getMessage(), 'download the content and pass it in' ) !== false
 		) {
-			$image = $this->getImage( $imageUrl, $crop, self::DO_DOWNLOAD_IMAGE );
-			$response = $this->imageAnnotator->documentTextDetection(
-				$image->getData(),
-				[ 'imageContext' => $imageContext ]
-			);
+			$image = $this->getImage( $imageUrl, $crop, self::DO_DOWNLOAD_IMAGE, $rotate );
+			$response = $this->imageAnnotator->textDetection( $image->getData(), [ 'imageContext' => $imageContext ] );
 		}
 
 		// Other errors, report to the user.

--- a/src/Engine/Image.php
+++ b/src/Engine/Image.php
@@ -16,6 +16,9 @@ class Image {
 	/** @var int[] Array of floats with keys: `x`, `y`, `width`, and `height`. */
 	private $crop;
 
+	/** @var int Rotation angle in degrees. */
+	private $rotate;
+
 	/** @var string|null Image data. */
 	private $data;
 
@@ -25,10 +28,12 @@ class Image {
 	/**
 	 * @param string $imageUrl
 	 * @param int[] $crop
+	 * @param int $rotate
 	 */
-	public function __construct( string $imageUrl, array $crop = [] ) {
+	public function __construct( string $imageUrl, array $crop = [], int $rotate = 0 ) {
 		$this->imageUrl = $imageUrl;
 		$this->crop = $crop;
+		$this->rotate = $rotate;
 	}
 
 	/**
@@ -51,6 +56,22 @@ class Image {
 			new Point( $this->crop['x'], $this->crop['y'] ),
 			new Box( $this->crop['width'], $this->crop['height'] )
 		);
+	}
+
+	/**
+	 * Check if rotation is needed.
+	 * @return bool
+	 */
+	public function needsRotation(): bool {
+		return $this->rotate !== 0;
+	}
+
+	/**
+	 * Get the rotation angle in degrees.
+	 * @return int
+	 */
+	public function getRotate(): int {
+		return $this->rotate;
 	}
 
 	public function hasData(): bool {

--- a/src/Engine/TesseractEngine.php
+++ b/src/Engine/TesseractEngine.php
@@ -51,14 +51,15 @@ class TesseractEngine extends EngineBase {
 		string $imageUrl,
 		string $invalidLangsMode,
 		array $crop,
-		?array $langs = null
+		?array $langs = null,
+		int $rotate = 0
 	): EngineResult {
 		// Check the URL and fetch the image data.
 		$this->checkImageUrl( $imageUrl );
 
 		[ $validLangs, $invalidLangs ] = $this->filterValidLangs( $langs, $invalidLangsMode );
 
-		$image = $this->getImage( $imageUrl, $crop, self::DO_DOWNLOAD_IMAGE );
+		$image = $this->getImage( $imageUrl, $crop, self::DO_DOWNLOAD_IMAGE, $rotate );
 		$this->ocr->imageData( $image->getData(), $image->getSize() );
 
 		if ( $validLangs ) {

--- a/src/Engine/TranskribusEngine.php
+++ b/src/Engine/TranskribusEngine.php
@@ -114,7 +114,8 @@ class TranskribusEngine extends EngineBase {
 		string $imageUrl,
 		string $invalidLangsMode,
 		array $crop,
-		?array $langs = null
+		?array $langs = null,
+		int $rotate = 0
 	): EngineResult {
 		$this->checkImageUrl( $imageUrl );
 
@@ -140,7 +141,7 @@ class TranskribusEngine extends EngineBase {
 		$modelCode = $validLangs[0];
 		$modelInfo = $this->getModelList()[$modelCode];
 		$htrModelId = (int)$modelInfo['htr'];
-		$image = $this->getImage( $imageUrl, $crop, self::DO_DOWNLOAD_IMAGE );
+		$image = $this->getImage( $imageUrl, $crop, self::DO_DOWNLOAD_IMAGE, $rotate );
 		$processId = $this->transkribusClient->initProcess( $image, $htrModelId, $this->lineId, $points );
 
 		$resText = '';

--- a/templates/output.html.twig
+++ b/templates/output.html.twig
@@ -62,6 +62,8 @@
 
         {% include '_transkribus_options.html.twig' with {engine: engine} %}
 
+        <input type="hidden" name="rotate" id="rotate" value="{{ rotate }}" />
+
         <div class="form-group submit-btn">
             <input type="submit" value="{{ msg( 'submit' ) }}" class="submit-full btn btn-info" />
         </div>
@@ -73,46 +75,56 @@
             </p>
         </div>
 
-        {% if text is defined %}
-            <div class="ocr-output">
-                <hr/>
-                <p class="nojs-hide">{{ msg('drag-help') }}</p>
-                <div class="row">
-                    <div class="col-md-6">
-                        <div class="output-buttons nojs-hide">
-                            <div class="btn-group" role="group">
-                                <button type="button" class="btn btn-default drag-mode drag-mode-crop"
-                                        title="{{ msg('drag-mode-crop') }}" data-drag-mode="crop">
-                                    <img src="{{ asset('build/images/Crop_-_The_Noun_Project.svg') }}" height="20" width="20"
-                                         alt="{{ msg('drag-mode-crop-alt') }}" />
-                                </button>
-                                <button type="button" class="btn btn-default drag-mode drag-mode-move active"
-                                        title="{{ msg('drag-mode-move') }}" data-drag-mode="move">
-                                    <img src="{{ asset('build/images/OOjs_UI_icon_move.svg') }}" height="20" width="20"
-                                         alt="{{ msg('drag-mode-move-alt') }}" />
-                                </button>
-                            </div>
-
-                            <input type="submit" value="{{ msg( 'submit-crop' ) }}" class="submit-crop btn btn-info disabled" disabled />
-
-                            <input type="hidden" name="crop[x]" value="{% if crop.x is defined %}{{ crop.x }}{% endif %}" />
-                            <input type="hidden" name="crop[y]" value="{% if crop.y is defined %}{{ crop.y }}{% endif %}" />
-                            <input type="hidden" name="crop[width]" value="{% if crop.width is defined %}{{ crop.width }}{% endif %}" />
-                            <input type="hidden" name="crop[height]" value="{% if crop.height is defined %}{{ crop.height }}{% endif %}" />
+        <div class="ocr-output nojs-hide {% if not image %}hidden{% endif %}">
+            <hr/>
+            <p class="nojs-hide">{{ msg('drag-help') }}</p>
+            <div class="row">
+                <div class="col-md-6">
+                    <div class="output-buttons nojs-hide">
+                        <div class="btn-group" role="group">
+                            <button type="button" class="btn btn-default drag-mode drag-mode-crop"
+                                    title="{{ msg('drag-mode-crop') }}" data-drag-mode="crop">
+                                <img src="{{ asset('build/images/Crop_-_The_Noun_Project.svg') }}" height="20" width="20"
+                                     alt="{{ msg('drag-mode-crop-alt') }}" />
+                            </button>
+                            <button type="button" class="btn btn-default drag-mode drag-mode-move active"
+                                    title="{{ msg('drag-mode-move') }}" data-drag-mode="move">
+                                <img src="{{ asset('build/images/OOjs_UI_icon_move.svg') }}" height="20" width="20"
+                                     alt="{{ msg('drag-mode-move-alt') }}" />
+                            </button>
                         </div>
-                        <div><!-- This div is required for Cropper.js -->
-                            <img id="source-image" class="img-responsive" src="{{ app.request.get('image') }}" alt="{{ msg('img-alt-text') }}" />
+
+                        <div class="btn-group" role="group">
+                            <button type="button" class="btn btn-default rotate-left"
+                                    title="{{ msg('rotate-left') }}" aria-label="{{ msg('rotate-left') }}">
+                                ↺
+                            </button>
+                            <button type="button" class="btn btn-default rotate-right"
+                                    title="{{ msg('rotate-right') }}" aria-label="{{ msg('rotate-right') }}">
+                                ↻
+                            </button>
                         </div>
+
+                        <input type="submit" value="{{ msg( 'submit-crop' ) }}" class="submit-crop btn btn-info disabled" disabled />
+
+                        <input type="hidden" name="crop[x]" value="{% if crop.x is defined %}{{ crop.x }}{% endif %}" />
+                        <input type="hidden" name="crop[y]" value="{% if crop.y is defined %}{{ crop.y }}{% endif %}" />
+                        <input type="hidden" name="crop[width]" value="{% if crop.width is defined %}{{ crop.width }}{% endif %}" />
+                        <input type="hidden" name="crop[height]" value="{% if crop.height is defined %}{{ crop.height }}{% endif %}" />
                     </div>
-                    <div class="col-md-6">
-                        <div class="output-buttons nojs-hide">
-                            <button class="btn btn-info copy-button" data-copied-text="{{ msg('copied-to-clipboard') }}">{{ msg( 'copy-to-clipboard' ) }}</button>
-                        </div>
-                        <textarea class="form-control" rows="{{ text|textarea_rows }}" id="text">{{ text }}</textarea>
+                    <div><!-- This div is required for Cropper.js -->
+                        <img id="source-image" class="img-responsive" src="{{ image }}" alt="{{ msg('image-alt-text') }}" />
                     </div>
                 </div>
+                <div class="col-md-6">
+                    <div class="output-buttons nojs-hide">
+                        <button class="btn btn-info copy-button {% if text is not defined %}hidden{% endif %}"
+                                data-copied-text="{{ msg('copied-to-clipboard') }}">{{ msg( 'copy-to-clipboard' ) }}</button>
+                    </div>
+                    <textarea class="form-control" rows="{% if text is defined %}{{ text|textarea_rows }}{% else %}10{% endif %}" id="text">{% if text is defined %}{{ text }}{% endif %}</textarea>
+                </div>
             </div>
-        {% endif %}
+        </div>
     </form>
 
 {% endblock %}


### PR DESCRIPTION
Fixes [T413556](https://phabricator.wikimedia.org/T413556)


- the image preview panel with rotation control now appears immediately after pasting a URL in the input box.
- Users can rotate the image before making any OCR request, eliminating the need for a double request (previously, preview tools only appeared after the first OCR request).
- Added i18n localization for rotation controls and button labels.

<img width="1728" height="1005" alt="Screenshot 2026-03-01 at 18 03 41" src="https://github.com/user-attachments/assets/c223b778-ebc9-4610-b89f-983ce1c66abd" />

