### PR TITLE
T411447 - Load models config directly rather than proxying via MediaWiki

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -7,42 +7,55 @@ const $select2 = $('#lang');
 var selectedLanguages = [];
 const $lineDetectionSelect = $('#line-id');
 var lineModels = null;
+var modelsData = null;
 
 const Cropper = require('cropperjs');
 import 'cropperjs/dist/cropper.css';
 
 /**
+ * Fetch /models.json once and cache the result.
+ * @return {jQuery.Promise}
+ */
+function fetchModelsJSON() {
+    return $.getJSON('/models.json').then(response => {
+        modelsData = response;
+    });
+}
+
+/**
  * Populate and re-initialize the Select2 input with languages supported by the given engine.
+ * Uses the cached modelsData from /models.json instead of making per-engine API calls.
  * @param {String} engine Supported engine ID such as 'google' or 'tesseract'.
  */
 function updateSelect2Options(engine)
 {
-    $.getJSON(`/api/available_langs?engine=${engine}`).then(response => {
-        const langs = response.available_langs;
-        let data = [];
+    if (!modelsData || !modelsData[engine]) {
+        return;
+    }
+    const models = modelsData[engine];
+    let data = [];
 
-        // Transform to data structure needed by Select2.
-        Object.keys(langs).forEach(lang => {
-            data.push({
-                id: lang,
-                text: `${lang} – ${langs[lang]}`,
-            });
+    // Transform to data structure needed by Select2, sorted alphabetically by model code.
+    Object.keys(models).sort().forEach(modelCode => {
+        data.push({
+            id: modelCode,
+            text: `${modelCode} – ${models[modelCode].title}`,
         });
-
-        // First clear any existing selections and empty all options.
-        $select2.val(null)
-            .empty()
-            .trigger('change');
-
-        // Update Select2 with the new options.
-        data.forEach(datum => {
-            const option = new Option(datum.text, datum.id, false, false);
-            $select2.append(option);
-        });
-
-        // Update selected languages.
-        $select2.val(selectedLanguages).trigger('change');
     });
+
+    // First clear any existing selections and empty all options.
+    $select2.val(null)
+        .empty()
+        .trigger('change');
+
+    // Update Select2 with the new options.
+    data.forEach(datum => {
+        const option = new Option(datum.text, datum.id, false, false);
+        $select2.append(option);
+    });
+
+    // Update selected languages.
+    $select2.val(selectedLanguages).trigger('change');
 }
 
 function fetchLineModelsJSON () {
@@ -84,6 +97,12 @@ $(function () {
 
     // fetch line detection model data
     fetchLineModelsJSON();
+
+    // Read pre-selected languages from data attribute (set by server from URL params).
+    var preSelectedLangs = $select2.data('selected-langs');
+    if (Array.isArray(preSelectedLangs)) {
+        selectedLanguages = preSelectedLangs;
+    }
 
     // Remove nojs class, for styling non-Javascript users.
     $('html').removeClass('nojs');
@@ -142,6 +161,12 @@ $(function () {
     } else {
         $select2.attr('data-placeholder', previousDataPlaceholder);
     }
+
+    // Fetch models.json and populate the language dropdown for the current engine.
+    fetchModelsJSON().then(() => {
+        const currentEngine = $('[name=engine]:checked').val() || 'google';
+        updateSelect2Options(currentEngine);
+    });
 
     // For the result page. Makes the 'Copy' button copy the transcription to the clipboard.
     const $copyButton = $('.copy-button');

--- a/src/Controller/OcrController.php
+++ b/src/Controller/OcrController.php
@@ -174,10 +174,6 @@ class OcrController extends AbstractController {
 	public function homeAction(): Response {
 		$this->setup();
 
-		// Pre-supply available langs for autocompletion in the form.
-		static::$params['available_langs'] = $this->engine->getValidModels( true );
-		ksort( static::$params['available_langs'] );
-
 		// set empty array to avoid errors while rendering template on non-transkribus engines
 		static::$params['available_line_ids'] = [];
 

--- a/templates/output.html.twig
+++ b/templates/output.html.twig
@@ -42,17 +42,13 @@
                     class="form-control"
                     name="langs[]"
                     multiple
+                    data-selected-langs="{{ langs|json_encode }}"
                     {% if engine == 'transkribus' %}
                         required
                     {% else %}
                         data-placeholder="{{ msg('langs-placeholder') }}"
                     {% endif %}
                 >
-                    {% for lang_code,lang_name in available_langs %}
-                        <option value="{{ lang_code }}" {% if lang_code in langs %}selected{% endif %}>
-                            {{- lang_code }} &ndash; {{ lang_name -}}
-                        </option>
-                    {% endfor %}
                 </select>
                 {% include '_transkribus_help.html.twig' with {engine: engine} %}
             </div>


### PR DESCRIPTION
Fixes - [T411447](https://phabricator.wikimedia.org/T411447)

**Load models client-side from /models.json**

- Fetch and cache `/models.json` once in `assets/app.js` and populate Select2 from that cache.
- Remove per‑engine `/api/available_langs` calls and prevent duplicate calls
- Remove `getValidModels()`/`ksort()` call from `src/Controller/OcrController.php::homeAction()` so the server no longer reads `models.json` on page load
