### PR TITLE
T411447: Fix the CORS error when fetching https://ocr.wmcloud.org/models.json

### DIFF
--- a/config/packages/nelmio_api_doc.yaml
+++ b/config/packages/nelmio_api_doc.yaml
@@ -7,6 +7,4 @@ nelmio_api_doc:
     areas:
         path_patterns:
             - ^/api$
-            - ^/api/available_langs$
-            - ^/api/tesseract/available_psms$
-            - ^/api/transkribus/available_line_ids$
+            - ^/api/

--- a/src/Controller/OcrController.php
+++ b/src/Controller/OcrController.php
@@ -295,6 +295,28 @@ class OcrController extends AbstractController {
 	}
 
 	/**
+	 * Serve the models config with CORS headers so it can be fetched directly
+	 * from the Wikisource frontend without requiring a MediaWiki proxy.
+	 * Returns a simplified map of engine->{code: title} matching the shape
+	 * previously provided by the available_langs API.
+	 *
+	 * @Route("/api/models", name="apiModels", methods={"GET"})
+	 * @return JsonResponse
+	 */
+	public function apiModelsAction(): JsonResponse {
+		$path = $this->getParameter( 'kernel.project_dir' ) . '/public/models.json';
+		$raw = json_decode( file_get_contents( $path ), true );
+		$out = [];
+		foreach ( $raw as $engine => $models ) {
+			$out[ $engine ] = [];
+			foreach ( $models as $code => $info ) {
+				$out[ $engine ][ $code ] = $info[ 'title' ];
+			}
+		}
+		return $this->getApiResponse( $out );
+	}
+
+	/**
 	 * Get a list of models available for use with a specific OCR engine.
 	 *
 	 * @Route("/api/available_langs", name="apiLangs", methods={"GET"})


### PR DESCRIPTION
Related Phabricator Task - [T411447](https://phabricator.wikimedia.org/T411447)
Related Gerrit Patch - https://gerrit.wikimedia.org/r/c/mediawiki/extensions/Wikisource/+/1247993

This PR fixes the CORS error when fetching  [https://ocr.wmcloud.org/models.json](https://ocr.wmcloud.org/models.json) from inside the Wikisource extension.

I attempted to fetch https://ocr.wmcloud.org/models.json directly from the frontend. However, because this file is served as a static asset by nginx (not by Symfony/PHP), it did not include the required Access-Control-Allow-Origin header, resulting in a CORS error in browsers.

To resolve this, the PR introduces a new Symfony route `/api/models` that reads and returns the contents of models.json with the correct CORS headers. This ensures the model data is accessible to the frontend, matches the expected data structure, and is served with the necessary CORS headers, while leaving the static file untouched.