### PR TITLE
Fix: handle array input for engine parameter in OcrController

### DIFF
--- a/src/Controller/OcrController.php
+++ b/src/Controller/OcrController.php
@@ -91,6 +91,9 @@ class OcrController extends AbstractController {
 	 */
 	private function setup(): void {
 		$requestedEngine = $this->request->query->get( 'engine', static::$params['engine'] );
+		if ( is_array( $requestedEngine ) ) {
+			$requestedEngine = $requestedEngine[0] ?? static::$params['engine'];
+		}
 		try {
 			$this->engine = $this->engineFactory->get( $requestedEngine );
 		} catch ( EngineNotFoundException $e ) {


### PR DESCRIPTION
Fixes error when 'engine' parameter is passed as an array.

Previously, passing engine[]=tesseract caused a TypeError because EngineFactory::get() expects a string.

This change ensures that if the 'engine' parameter is an array, the first value is extracted before passing it to the factory.

Tested locally using PHP built-in server.