### PR TITLE
Fix: handle array input for engine parameter to prevent TypeError

### DIFF
--- a/src/Controller/OcrController.php
+++ b/src/Controller/OcrController.php
@@ -91,15 +91,22 @@ class OcrController extends AbstractController {
 	 */
 	private function setup(): void {
 		$requestedEngine = $this->request->query->get( 'engine', static::$params['engine'] );
-		try {
-			$this->engine = $this->engineFactory->get( $requestedEngine );
-		} catch ( EngineNotFoundException $e ) {
-			$this->addFlash( 'error', $this->intuition->msg(
-				'engine-not-found-warning',
-				[ 'variables' => [ $requestedEngine, static::DEFAULT_ENGINE ] ]
+
+	 	// If engine is passed as an array (e.g., engine[]=tesseract),
+		// take the first value to prevent TypeError
+		if ( is_array( $requestedEngine ) ) {
+    		$requestedEngine = $requestedEngine[0] ?? static::DEFAULT_ENGINE;
+		}
+ 
+	 	try {
+		    $this->engine = $this->engineFactory->get( $requestedEngine );
+	 	 } catch ( EngineNotFoundException $e ) {
+		 	$this->addFlash( 'error', $this->intuition->msg(
+			 	'engine-not-found-warning',
+			    [ 'variables' => [ $requestedEngine, static::DEFAULT_ENGINE ] ]
 			) );
 			$this->engine = $this->engineFactory->get( static::DEFAULT_ENGINE );
-		}
+	}
 
 		static::$params['engine'] = $this->engine::getId();
 		$this->setEngineOptions();


### PR DESCRIPTION
## Description

This PR fixes an issue where passing the `engine` parameter as an array (e.g., `engine[]=tesseract`) caused a TypeError in the application.

## Changes made

- Added handling for array input in the `engine` parameter
- Ensured the first value is safely extracted when an array is provided
- Prevented application crash by validating input type

## Testing

Tested the following cases locally:

- `engine=tesseract` → works correctly
- `engine[]=tesseract` → handled safely without crashing

## Notes

This ensures the application behaves correctly even when the `engine` parameter is passed incorrectly as an array.