### PR TITLE
i18n: add bulk OCR messages and rate limiting docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,16 @@ Please report bugs via Phabricator: https://phabricator.wikimedia.org/tag/wikime
 * Wikimedia OCR is GPL 3.0 or later (see the LICENSE file)
 * [Crop_-_The_Noun_Project.svg](https://commons.wikimedia.org/wiki/File:Crop_-_The_Noun_Project.svg) is CC0
 * [OOjs_UI_icon_move.svg](https://commons.wikimedia.org/wiki/File:OOjs_UI_icon_move.svg) is CC-BY-SA-4.0 
+
+## API Rate Limiting
+
+The Wikimedia OCR API applies rate limiting to prevent abuse. When integrating
+this service into tools that perform bulk operations (such as OCR-ing multiple
+pages of a book), implementors should:
+
+- Add a delay of at least 1 second between consecutive OCR requests
+- Handle `429 Too Many Requests` responses with exponential backoff
+- Check the `Retry-After` header when a rate limit response is received
+
+For bulk OCR workflows, it is recommended to process pages sequentially
+rather than in parallel to stay within rate limits.

--- a/README.md
+++ b/README.md
@@ -21,15 +21,4 @@ Please report bugs via Phabricator: https://phabricator.wikimedia.org/tag/wikime
 * [Crop_-_The_Noun_Project.svg](https://commons.wikimedia.org/wiki/File:Crop_-_The_Noun_Project.svg) is CC0
 * [OOjs_UI_icon_move.svg](https://commons.wikimedia.org/wiki/File:OOjs_UI_icon_move.svg) is CC-BY-SA-4.0 
 
-## API Rate Limiting
 
-The Wikimedia OCR API applies rate limiting to prevent abuse. When integrating
-this service into tools that perform bulk operations (such as OCR-ing multiple
-pages of a book), implementors should:
-
-- Add a delay of at least 1 second between consecutive OCR requests
-- Handle `429 Too Many Requests` responses with exponential backoff
-- Check the `Retry-After` header when a rate limit response is received
-
-For bulk OCR workflows, it is recommended to process pages sequentially
-rather than in parallel to stay within rate limits.

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -79,9 +79,4 @@
     "transkribus-job-start": "Started",
     "transkribus-job-end": "Finished",
     "transkribus-job-waited": "Start delay (minutes)"
-	"wikimedia-ocr-bulk-submit": "Run OCR on all selected pages",
-    "wikimedia-ocr-bulk-progress": "Processing page $1 of $2",
-    "wikimedia-ocr-bulk-success": "OCR completed successfully for $1 pages",
-    "wikimedia-ocr-bulk-error": "OCR failed for page $1. Please try again.",
-    "wikimedia-ocr-bulk-permission-denied": "You do not have permission to perform bulk OCR operations."
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -79,4 +79,9 @@
     "transkribus-job-start": "Started",
     "transkribus-job-end": "Finished",
     "transkribus-job-waited": "Start delay (minutes)"
+	"wikimedia-ocr-bulk-submit": "Run OCR on all selected pages",
+    "wikimedia-ocr-bulk-progress": "Processing page $1 of $2",
+    "wikimedia-ocr-bulk-success": "OCR completed successfully for $1 pages",
+    "wikimedia-ocr-bulk-error": "OCR failed for page $1. Please try again.",
+    "wikimedia-ocr-bulk-permission-denied": "You do not have permission to perform bulk OCR operations."
 }


### PR DESCRIPTION
This PR adds:
- i18n messages for the upcoming bulk OCR feature (T415145)
- Documentation for API rate limiting behavior relevant to bulk operations

Related to GSoC 2026 project: Bulk OCR Improvements