### PR TITLE
T421660: eslint enforce no-unused-vars

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,7 +13,6 @@
 	},
 	"rules": {
 		"no-jquery/no-global-selector": "warn",
-		"no-unused-vars": "warn",
 		"no-new": "warn",
 		"semi-style": "warn",
 		"yml/no-empty-document": "warn",

--- a/assets/app.js
+++ b/assets/app.js
@@ -154,12 +154,12 @@ $( () => {
 	}
 
 	const $submitBtns = $( '.submit-full, .submit-crop' );
-	$submitBtns.closest( 'form' ).on( 'submit', ( e ) => {
+	$submitBtns.closest( 'form' ).on( 'submit', () => {
 		$submitBtns.attr( 'disabled', true );
 		$( '.loader' ).removeClass( 'hidden' );
 	} );
 	// Re-enable submit buttons on pagehide, so that they are re-enabled if returned to via browser history
-	$( window ).on( 'pagehide', ( e ) => {
+	$( window ).on( 'pagehide', () => {
 		$submitBtns.attr( 'disabled', false );
 		$( '.loader' ).addClass( 'hidden' );
 	} );
@@ -212,12 +212,12 @@ $( () => {
 		} );
 
 		// When setting a new image URL, remove the preview and the crop dimensions.
-		$( '[name=image]' ).on( 'change', ( e ) => {
+		$( '[name=image]' ).on( 'change', () => {
 			$ocrOutputDiv.remove();
 		} );
 
 		// When submitting the main 'transcribe' button, do not send crop dimensions.
-		$( '.submit-full' ).on( 'click', ( e ) => {
+		$( '.submit-full' ).on( 'click', () => {
 			x.value = null;
 			y.value = null;
 			width.value = null;


### PR DESCRIPTION
Related Phabricator Task - [T421660](https://phabricator.wikimedia.org/T421660)

- remove `no-unused-vars` from .eslintrc.json
- fix `no-unused-vars` errors
- `npm run test` passes
- verify that there are no breaks in functionality