### PR TITLE
T421660: eslint enforce yml/no-empty-document

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,7 +12,6 @@
 		"sourceType": "module"
 	},
 	"rules": {
-		"no-jquery/no-global-selector": "warn",
-		"yml/no-empty-document": "warn"
+		"no-jquery/no-global-selector": "warn"
 	}
 }

--- a/config/packages/prod/deprecations.yaml
+++ b/config/packages/prod/deprecations.yaml
@@ -1,8 +1,0 @@
-# As of Symfony 5.1, deprecations are logged in the dedicated "deprecation" channel when it exists
-# monolog:
-#    channels: [deprecation]
-#    handlers:
-#        deprecation:
-#            type: stream
-#            channels: [deprecation]
-#            path: php://stderr

--- a/config/packages/prod/webpack_encore.yaml
+++ b/config/packages/prod/webpack_encore.yaml
@@ -1,4 +1,0 @@
-# webpack_encore:
-    # Cache the entrypoints.json (rebuild Symfony's cache when entrypoints.json changes)
-    # Available in version 1.2
-    # cache: true

--- a/config/packages/test/webpack_encore.yaml
+++ b/config/packages/test/webpack_encore.yaml
@@ -1,2 +1,0 @@
-# webpack_encore:
-#    strict_mode: false


### PR DESCRIPTION
Related Phabricator Task - [T421660](https://phabricator.wikimedia.org/T421660)

the yaml documents have commented out content in them. I am not sure deleting the files will be an accepted option so I have added the `~` character to make eslint see them as `non-empty`

- remove `yml/no-empty-document` from .eslintrc.json
- fix `yml/no-empty-document` errors 
- `npm run test` passes