### PR TITLE
T421660: eslint enforce yml/no-empty-mapping-value

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,7 +13,6 @@
 	},
 	"rules": {
 		"no-jquery/no-global-selector": "warn",
-		"yml/no-empty-document": "warn",
-		"yml/no-empty-mapping-value": "warn"
+		"yml/no-empty-document": "warn"
 	}
 }

--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -1,4 +1,4 @@
 doctrine:
   dbal:
     connections:
-      default:
+      default: ~

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -60,7 +60,7 @@ services:
       - { name: kernel.event_listener, event: kernel.exception }
 
     # Vendor services for autowiring
-  thiagoalessio\TesseractOCR\TesseractOCR:
+  thiagoalessio\TesseractOCR\TesseractOCR: ~
 
   # please note that last definitions always *replace* previous ones
   # add more service definitions when explicit configuration is needed


### PR DESCRIPTION
Related Phabricator Task - [T421660](https://phabricator.wikimedia.org/T421660)

since empty value and `~` appear to both represent `null` in yaml. I have added `~` as a placeholder to satisfy the rule

- remove `yml/no-empty-mapping-value` from .eslintrc.json
- fix `yml/no-empty-mapping-value` errors 
- `npm run test` passes